### PR TITLE
Updates compileCypher method so it properly exports its typings

### DIFF
--- a/src/utils/compile-cypher-if-exists.ts
+++ b/src/utils/compile-cypher-if-exists.ts
@@ -18,16 +18,16 @@
  */
 
 import type { CypherEnvironment } from "../Environment";
-import { Clause } from "../clauses/Clause";
-import { Expr } from "../types";
-import { compileCypher } from "./compile-cypher";
+import { CypherCompilable } from "../types";
 
 /** Compiles the cypher of an element, if the resulting cypher is not empty adds a prefix */
 export function compileCypherIfExists(
-    element: Expr | Clause | undefined,
+    element: CypherCompilable | undefined,
     env: CypherEnvironment,
-    options: { prefix?: string; suffix?: string } = {}
+    { prefix = "", suffix = "" }: { prefix?: string; suffix?: string } = {}
 ): string {
     if (!element) return "";
-    return compileCypher(element, env, options);
+    const cypher = element.getCypher(env);
+    if (!cypher) return "";
+    return `${prefix}${cypher}${suffix}`;
 }

--- a/src/utils/compile-cypher-if-exists.ts
+++ b/src/utils/compile-cypher-if-exists.ts
@@ -18,12 +18,13 @@
  */
 
 import type { CypherEnvironment } from "../Environment";
-import type { CypherCompilable } from "../types";
+import { Clause } from "../clauses/Clause";
+import { Expr } from "../types";
 import { compileCypher } from "./compile-cypher";
 
 /** Compiles the cypher of an element, if the resulting cypher is not empty adds a prefix */
 export function compileCypherIfExists(
-    element: CypherCompilable | undefined,
+    element: Expr | Clause | undefined,
     env: CypherEnvironment,
     options: { prefix?: string; suffix?: string } = {}
 ): string {

--- a/src/utils/compile-cypher.ts
+++ b/src/utils/compile-cypher.ts
@@ -18,7 +18,8 @@
  */
 
 import type { CypherEnvironment } from "../Environment";
-import type { CypherCompilable } from "../types";
+import { Clause } from "../clauses/Clause";
+import type { Expr } from "../types";
 import { isCypherCompilable } from "./is-cypher-compilable";
 
 /** Compiles a clause or expression to a Cypher string, adding optional prefix or suffix. To be used in a RawCypher callback
@@ -26,7 +27,7 @@ import { isCypherCompilable } from "./is-cypher-compilable";
  *  The prefix and suffix will only be added if the resulting Cypher is **not** an empty string
  */
 export function compileCypher(
-    element: CypherCompilable,
+    element: Expr | Clause,
     env: CypherEnvironment,
     { prefix = "", suffix = "" }: { prefix?: string; suffix?: string } = {}
 ): string {


### PR DESCRIPTION
Minor change in types so this properly exports, as `CypherCompilable` is not really a valid type for the end user