### PR TITLE
Escape properties in patterns

### DIFF
--- a/.changeset/large-eels-provide.md
+++ b/.changeset/large-eels-provide.md
@@ -1,0 +1,11 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Escapes properties in patterns.
+
+e.g.
+
+```
+MATCH (m:Movie { `$myProp`: "Text" })
+```

--- a/src/clauses/Merge.test.ts
+++ b/src/clauses/Merge.test.ts
@@ -20,7 +20,7 @@
 import Cypher from "..";
 
 describe("CypherBuilder Merge", () => {
-    test("Merge node", () => {
+    test("Merge node onCreate", () => {
         const node = new Cypher.Node({
             labels: ["MyLabel"],
         });
@@ -34,10 +34,30 @@ describe("CypherBuilder Merge", () => {
                 this0.age = $param0"
         `);
         expect(queryResult.params).toMatchInlineSnapshot(`
-{
-  "param0": 23,
-}
-`);
+            {
+              "param0": 23,
+            }
+        `);
+    });
+
+    test("Merge node onCreate with escaped property", () => {
+        const node = new Cypher.Node({
+            labels: ["MyLabel"],
+        });
+
+        const query = new Cypher.Merge(node).onCreate([node.property("$age"), new Cypher.Param(23)]);
+
+        const queryResult = query.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "MERGE (this0:\`MyLabel\`)
+            ON CREATE SET
+                this0.\`$age\` = $param0"
+        `);
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": 23,
+            }
+        `);
     });
 
     test("Merge node with parameters", () => {
@@ -61,11 +81,11 @@ describe("CypherBuilder Merge", () => {
                 this0.age = $param1"
         `);
         expect(queryResult.params).toMatchInlineSnapshot(`
-{
-  "param0": "test",
-  "param1": 23,
-}
-`);
+            {
+              "param0": "test",
+              "param1": 23,
+            }
+        `);
     });
 
     test("Merge relationship", () => {
@@ -94,12 +114,12 @@ describe("CypherBuilder Merge", () => {
             RETURN this0.title AS movie"
         `);
         expect(queryResult.params).toMatchInlineSnapshot(`
-{
-  "param0": 23,
-  "param1": "Keanu",
-  "param2": 10,
-}
-`);
+            {
+              "param0": 23,
+              "param1": "Keanu",
+              "param2": 10,
+            }
+        `);
     });
 
     test("Merge relationship with path assign", () => {
@@ -130,12 +150,12 @@ describe("CypherBuilder Merge", () => {
             RETURN this1.title AS movie"
         `);
         expect(queryResult.params).toMatchInlineSnapshot(`
-{
-  "param0": 23,
-  "param1": "Keanu",
-  "param2": 10,
-}
-`);
+            {
+              "param0": 23,
+              "param1": "Keanu",
+              "param2": 10,
+            }
+        `);
     });
 
     test("Merge node and delete", () => {

--- a/src/pattern/Pattern.test.ts
+++ b/src/pattern/Pattern.test.ts
@@ -47,10 +47,23 @@ describe("Patterns", () => {
             const queryResult = new TestClause(pattern).build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0:\`TestLabel\` { name: $param0 })"`);
             expect(queryResult.params).toMatchInlineSnapshot(`
-{
-  "param0": "test",
-}
-`);
+                {
+                  "param0": "test",
+                }
+            `);
+        });
+
+        test("Node with escaped parameters and labels", () => {
+            const node = new Cypher.Node({ labels: ["TestLabel"] });
+
+            const pattern = new Cypher.Pattern(node).withProperties({ $_name: new Cypher.Param("test") });
+            const queryResult = new TestClause(pattern).build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0:\`TestLabel\` { \`$_name\`: $param0 })"`);
+            expect(queryResult.params).toMatchInlineSnapshot(`
+                {
+                  "param0": "test",
+                }
+            `);
         });
     });
 
@@ -106,14 +119,14 @@ describe("Patterns", () => {
             );
 
             expect(queryResult.params).toMatchInlineSnapshot(`
-{
-  "param0": "Arthur",
-  "param1": "Dent",
-  "param2": [
-    "neo",
-  ],
-}
-`);
+                {
+                  "param0": "Arthur",
+                  "param1": "Dent",
+                  "param2": [
+                    "neo",
+                  ],
+                }
+            `);
         });
 
         test("Long relationship Pattern", () => {
@@ -219,10 +232,10 @@ describe("Patterns", () => {
             );
 
             expect(queryResult.params).toMatchInlineSnapshot(`
-{
-  "param0": 100,
-}
-`);
+                {
+                  "param0": 100,
+                }
+            `);
         });
 
         test("variable length with empty relationship", () => {

--- a/src/pattern/PatternElement.ts
+++ b/src/pattern/PatternElement.ts
@@ -21,6 +21,7 @@ import { CypherEnvironment } from "../Environment";
 import type { NodeProperties, NodeRef } from "../references/NodeRef";
 import type { RelationshipProperties, RelationshipRef } from "../references/RelationshipRef";
 import type { CypherCompilable } from "../types";
+import { escapeProperty } from "../utils/escape";
 import { padBlock } from "../utils/pad-block";
 import { padLeft } from "../utils/pad-left";
 import { stringifyObject } from "../utils/stringify-object";
@@ -39,7 +40,8 @@ export abstract class PatternElement<T extends NodeRef | RelationshipRef> implem
     protected serializeParameters(parameters: NodeProperties | RelationshipProperties, env: CypherEnvironment): string {
         if (Object.keys(parameters).length === 0) return "";
         const paramValues = Object.entries(parameters).reduce((acc, [key, param]) => {
-            acc[key] = param.getCypher(env);
+            const escapedKey = escapeProperty(key);
+            acc[escapedKey] = param.getCypher(env);
             return acc;
         }, {} as Record<string, string>);
 


### PR DESCRIPTION
This PR fixes properties in patterns that need escaping:

For instance:
```
MATCH (m:Movie {$test: ""})
```

Needs to be changed to

```
MATCH(m:Movie {`$test`: ""})
```