### PR TITLE
Fix usage of any

### DIFF
--- a/.changeset/large-falcons-breathe.md
+++ b/.changeset/large-falcons-breathe.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Updates CypherResult type to Record<string, unknown>, better reflecting the results of the parameters

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -60,14 +60,14 @@ export class CypherEnvironment {
         return id;
     }
 
-    public getParams(): Record<string, any> {
-        return this.params.reduce((acc, param: Param) => {
+    public getParams(): Record<string, unknown> {
+        return this.params.reduce<Record<string, unknown>>((acc, param: Param) => {
             const key = this.getReferenceId(param);
             if (param.hasValue) {
                 acc[key] = param.value;
             }
             return acc;
-        }, {} as Record<string, any>);
+        }, {});
     }
 
     public addNamedParamReference(name: string, param: Param): void {
@@ -112,6 +112,7 @@ export class CypherEnvironment {
     }
 
     private isNamedReference(ref: Reference | NamedReference): ref is NamedReference {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return Boolean((ref as any).id);
     }
 }

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -31,7 +31,7 @@ const customInspectSymbol = Symbol.for("nodejs.util.inspect.custom");
  */
 export abstract class Clause extends CypherASTNode {
     /** Compiles a clause into Cypher and params */
-    public build(prefix?: string | EnvPrefix | undefined, extraParams: Record<string, any> = {}): CypherResult {
+    public build(prefix?: string | EnvPrefix | undefined, extraParams: Record<string, unknown> = {}): CypherResult {
         if (this.isRoot) {
             const env = this.getEnv(prefix);
             const cypher = this.getCypher(env);

--- a/src/clauses/utils/mixin.ts
+++ b/src/clauses/utils/mixin.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import type { ClauseMixin } from "../mixins/ClauseMixin";
 
 type ConstructorType<T> = new (...args: any[]) => T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,7 +72,7 @@ export type Predicate =
 
 export type CypherResult = {
     cypher: string;
-    params: Record<string, string>;
+    params: Record<string, unknown>;
 };
 
 /** Defines the interface for a class that can be compiled into Cypher */


### PR DESCRIPTION
Changes any for unknown where possible

exceptions have been marked with eslint-disable:
* mixins
* isNamedReference type checking


This is a technically breaking change as the exported type is now different 