### PR TITLE
Fix innerWith typings

### DIFF
--- a/.changeset/eleven-cameras-smell.md
+++ b/.changeset/eleven-cameras-smell.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Fix typings on innerWith so at least a parameter is required

--- a/src/apoc/cypher/run-first-column.test.ts
+++ b/src/apoc/cypher/run-first-column.test.ts
@@ -25,6 +25,20 @@ describe("apoc.cypher", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
         const subquery = new Cypher.Match(node).return(node);
 
+        const apocRunFirstColum = Cypher.apoc.cypher.runFirstColumnSingle(subquery);
+        const queryResult = new TestClause(apocRunFirstColum).build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "apoc.cypher.runFirstColumnSingle(\\"MATCH (this0:Movie)
+            RETURN this0\\", {  })"
+        `);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("runFirstColumnSingle with parameters", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+        const subquery = new Cypher.Match(node).return(node);
+
         const apocRunFirstColum = Cypher.apoc.cypher.runFirstColumnSingle(subquery, [node]);
         const queryResult = new TestClause(apocRunFirstColum).build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
@@ -36,6 +50,20 @@ describe("apoc.cypher", () => {
     });
 
     test("runFirstColumnMany", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+        const subquery = new Cypher.Match(node).return(node);
+
+        const apocRunFirstColum = Cypher.apoc.cypher.runFirstColumnMany(subquery);
+        const queryResult = new TestClause(apocRunFirstColum).build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "apoc.cypher.runFirstColumnMany(\\"MATCH (this0:Movie)
+            RETURN this0\\", {  })"
+        `);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("runFirstColumnMany with parameters", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
         const subquery = new Cypher.Match(node).return(node);
 

--- a/src/apoc/cypher/run-first-column.ts
+++ b/src/apoc/cypher/run-first-column.ts
@@ -86,7 +86,7 @@ class RunFirstColumnFunction extends CypherFunction {
         return query.replace(/("|\\)/g, "\\$1");
     }
 
-    private parseVariablesInput(variables: Variable[] | MapExpr | Record<string, Expr> = []): Variable[] | MapExpr {
+    private parseVariablesInput(variables: Variable[] | MapExpr | Record<string, Expr>): Variable[] | MapExpr {
         if (Array.isArray(variables) || variables instanceof MapExpr) return variables;
         return new MapExpr(variables);
     }

--- a/src/clauses/Call.test.ts
+++ b/src/clauses/Call.test.ts
@@ -97,6 +97,32 @@ describe("CypherBuilder Call", () => {
         `);
     });
 
+    test("CALL with inner with multiple parameters", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+
+        const matchClause = new Cypher.Match(node)
+            .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
+            .return([node.property("title"), "movie"]);
+
+        const clause = new Cypher.Call(matchClause).innerWith(node, new Cypher.Variable());
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "CALL {
+                WITH this0, var1
+                MATCH (this0:Movie)
+                WHERE $param0 = $param1
+                RETURN this0.title AS movie
+            }"
+        `);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": "aa",
+              "param1": "bb",
+            }
+        `);
+    });
+
     test("CALL with inner with fails if inner with is already set", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
 

--- a/src/clauses/Call.ts
+++ b/src/clauses/Call.ts
@@ -47,9 +47,9 @@ export class Call extends Clause {
         this.subQuery = rootQuery;
     }
 
-    public innerWith(...params: Variable[]): this {
+    public innerWith(firstParam: Variable, ...params: Variable[]): this {
         if (this.importWith) throw new Error("Call import already set");
-        this.importWith = new ImportWith(this, params);
+        this.importWith = new ImportWith(this, [firstParam, ...params]);
         this.addChildren(this.importWith);
         return this;
     }

--- a/src/expressions/operations/boolean.test.ts
+++ b/src/expressions/operations/boolean.test.ts
@@ -32,7 +32,7 @@ describe("boolean operations", () => {
             expect(cypher).toMatchInlineSnapshot(`"(coalesce(var0) AND max(var1))"`);
         });
 
-        test("and operation with single predicates", () => {
+        test("and operation with single predicate", () => {
             const and = Cypher.and(predicate1);
             const { cypher } = new TestClause(and).build();
             expect(cypher).toMatchInlineSnapshot(`"coalesce(var0)"`);


### PR DESCRIPTION
This PR fixes `Call().innerWith` typings, requiring at least one parameter, as `WITH` without parameters is not supported in Cypher

Some tests were added to cover some edge cases