### PR TITLE
Fix skip and limit parameters typings

### DIFF
--- a/.changeset/stupid-monkeys-check.md
+++ b/.changeset/stupid-monkeys-check.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Fix typings on `.skip()` and `.limit()` to support expressions

--- a/src/clauses/Return.test.ts
+++ b/src/clauses/Return.test.ts
@@ -162,5 +162,25 @@ describe("CypherBuilder Return", () => {
                 }
             `);
         });
+
+        test("Return with skip and limit expressions and no order", () => {
+            const movieNode = new Cypher.Node({
+                labels: ["Movie"],
+            });
+
+            const matchQuery = new Cypher.Return(movieNode)
+                .limit(Cypher.plus(new Cypher.Literal(5), new Cypher.Literal(5)))
+                .skip(Cypher.plus(new Cypher.Literal(2), new Cypher.Literal(2)));
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+                "RETURN this0
+
+                SKIP (2 + 2)
+                LIMIT (5 + 5)"
+            `);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
     });
 });

--- a/src/clauses/mixins/WithOrder.ts
+++ b/src/clauses/mixins/WithOrder.ts
@@ -21,9 +21,6 @@ import type { Order } from "../sub-clauses/OrderBy";
 import { OrderBy } from "../sub-clauses/OrderBy";
 import { ClauseMixin } from "./ClauseMixin";
 import type { Expr } from "../../types";
-import type { Param } from "../../references/Param";
-import type { Literal } from "../../references/Literal";
-import type { Integer } from "neo4j-driver";
 
 const DEFAULT_ORDER = "ASC";
 

--- a/src/clauses/mixins/WithOrder.ts
+++ b/src/clauses/mixins/WithOrder.ts
@@ -50,7 +50,7 @@ export abstract class WithOrder extends ClauseMixin {
     /** Add a `SKIP` subclause.
      * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/skip/)
      */
-    public skip(value: number | Param<Integer> | Param<number> | Literal<number>): this {
+    public skip(value: number | Expr): this {
         const orderByStatement = this.getOrCreateOrderBy();
         orderByStatement.skip(value);
         return this;
@@ -59,7 +59,7 @@ export abstract class WithOrder extends ClauseMixin {
     /** Add a `LIMIT` subclause.
      * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/limit/)
      */
-    public limit(value: number | Param<Integer> | Param<number> | Literal<number>): this {
+    public limit(value: number | Expr): this {
         const orderByStatement = this.getOrCreateOrderBy();
         orderByStatement.limit(value);
         return this;


### PR DESCRIPTION
This PR will fix the typings errors with queries such as:

```cypehr
RETURN n
SKIP 5+5
```