### PR TITLE
Support for expressions in properties within patterns

### DIFF
--- a/.changeset/nice-days-grow.md
+++ b/.changeset/nice-days-grow.md
@@ -1,0 +1,17 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Support for expressions on Pattern properties:
+
+```js
+const pattern = new Cypher.Pattern(node).withProperties({
+    name: Cypher.plus(new Cypher.Literal("The "), new Cypher.Literal("Matrix")),
+});
+```
+
+Results in:
+
+```cypher
+(this0: {name: "The " + "Matrix"})
+```

--- a/src/pattern/PartialPattern.ts
+++ b/src/pattern/PartialPattern.ts
@@ -17,15 +17,14 @@
  * limitations under the License.
  */
 
+import type { Environment, Variable } from "..";
 import type { CypherEnvironment } from "../Environment";
-import type { RelationshipRef } from "../references/RelationshipRef";
+import { LabelExpr } from "../expressions/labels/label-expressions";
 import { NodeRef } from "../references/NodeRef";
+import type { RelationshipProperties, RelationshipRef } from "../references/RelationshipRef";
+import { escapeType } from "../utils/escape";
 import { Pattern } from "./Pattern";
 import { PatternElement } from "./PatternElement";
-import type { Param } from "../references/Param";
-import { LabelExpr } from "../expressions/labels/label-expressions";
-import type { Environment, Variable } from "..";
-import { escapeType } from "../utils/escape";
 
 type LengthOption =
     | number
@@ -43,7 +42,7 @@ export class PartialPattern extends PatternElement<RelationshipRef> {
     private withVariable = true;
     private direction: "left" | "right" | "undirected" = "right";
     private previous: Pattern;
-    private properties: Record<string, Param> | undefined;
+    private properties: RelationshipProperties | undefined;
 
     constructor(rel: RelationshipRef, previous: Pattern) {
         super(rel);
@@ -70,7 +69,7 @@ export class PartialPattern extends PatternElement<RelationshipRef> {
         return this;
     }
 
-    public withProperties(properties: Record<string, Param>): this {
+    public withProperties(properties: RelationshipProperties): this {
         this.properties = properties;
         return this;
     }

--- a/src/pattern/Pattern.test.ts
+++ b/src/pattern/Pattern.test.ts
@@ -53,6 +53,19 @@ describe("Patterns", () => {
             `);
         });
 
+        test("Node with properties using expressions and labels", () => {
+            const node = new Cypher.Node({ labels: ["TestLabel"] });
+
+            const pattern = new Cypher.Pattern(node).withProperties({
+                name: Cypher.plus(new Cypher.Literal("The "), new Cypher.Literal("Matrix")),
+            });
+            const queryResult = new TestClause(pattern).build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(
+                `"(this0:TestLabel { name: (\\"The \\" + \\"Matrix\\") })"`
+            );
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
         test("Simple node with label that needs normalize", () => {
             const node = new Cypher.Node({ labels: ["Test&Label"] });
 
@@ -161,6 +174,30 @@ describe("Patterns", () => {
                   ],
                 }
             `);
+        });
+
+        test("Simple Pattern with expressions in properties", () => {
+            const a = new Cypher.Node({
+                labels: ["Person", "Actor"],
+            });
+
+            const b = new Cypher.Node();
+            const rel = new Cypher.Relationship({
+                type: "ACTED_IN",
+            });
+
+            const query = new TestClause(
+                new Cypher.Pattern(a)
+                    .related(rel)
+                    .withProperties({
+                        roles: Cypher.plus(new Cypher.Literal("The "), new Cypher.Literal("Matrix")),
+                    })
+                    .to(b)
+            );
+            const queryResult = query.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0:Person:Actor)-[this1:ACTED_IN { roles: (\\"The \\" + \\"Matrix\\") }]->(this2)"`);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });
 
         test("Long relationship Pattern", () => {

--- a/src/pattern/Pattern.ts
+++ b/src/pattern/Pattern.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
-import { LabelExpr } from "../expressions/labels/label-expressions";
+import type { Expr } from "..";
 import type { CypherEnvironment } from "../Environment";
+import { LabelExpr } from "../expressions/labels/label-expressions";
 import type { NodeRef } from "../references/NodeRef";
-import type { Param } from "../references/Param";
 import { RelationshipRef } from "../references/RelationshipRef";
+import type { Variable } from "../references/Variable";
 import { escapeLabel } from "../utils/escape";
 import { PartialPattern } from "./PartialPattern";
 import { PatternElement } from "./PatternElement";
-import type { Variable } from "../references/Variable";
 
 /** Represents a pattern of a single node or n-relationships to be used in clauses.
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/patterns/)
@@ -35,7 +35,7 @@ export class Pattern extends PatternElement<NodeRef> {
     private withLabels = true;
     private withVariable = true;
     private previous: PartialPattern | undefined;
-    private properties: Record<string, Param> | undefined;
+    private properties: Record<string, Expr> | undefined;
 
     constructor(node: NodeRef, previous?: PartialPattern) {
         super(node);
@@ -52,7 +52,7 @@ export class Pattern extends PatternElement<NodeRef> {
         return this;
     }
 
-    public withProperties(properties: Record<string, Param>): this {
+    public withProperties(properties: Record<string, Expr>): this {
         this.properties = properties;
         return this;
     }

--- a/src/references/NodeRef.ts
+++ b/src/references/NodeRef.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
+import type { Expr } from "..";
 import { HasLabel } from "../expressions/HasLabel";
 import { LabelExpr } from "../expressions/labels/label-expressions";
-import type { Param } from "./Param";
 import type { NamedReference } from "./Variable";
 import { Variable } from "./Variable";
 
-export type NodeProperties = Record<string, Param<unknown>>;
+export type NodeProperties = Record<string, Expr>;
 
 type NodeRefOptions = {
     labels?: Set<string> | Array<string> | LabelExpr;

--- a/src/references/RelationshipRef.ts
+++ b/src/references/RelationshipRef.ts
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-import type { NodeRef } from "./NodeRef";
-import type { Param } from "./Param";
+import type { Expr } from "..";
 import type { LabelExpr } from "../expressions/labels/label-expressions";
+import type { NodeRef } from "./NodeRef";
 import type { NamedReference } from "./Variable";
 import { Variable } from "./Variable";
 
@@ -29,7 +29,7 @@ export type RelationshipInput = {
     type?: string;
 };
 
-export type RelationshipProperties = Record<string, Param<unknown>>;
+export type RelationshipProperties = Record<string, Expr>;
 
 type RelationshipRefOptions = {
     type?: string | LabelExpr;


### PR DESCRIPTION
Support for expressions on Pattern properties:

```js
const pattern = new Cypher.Pattern(node).withProperties({
    name: Cypher.plus(new Cypher.Literal("The "), new Cypher.Literal("Matrix")),
});
```

Results in:

```cypher
(this0: {name: "The " + "Matrix"})
```