### PR TITLE
Add chained subclauses to unwind

### DIFF
--- a/.changeset/empty-eyes-repeat.md
+++ b/.changeset/empty-eyes-repeat.md
@@ -1,0 +1,9 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for chained clauses in unwind:
+
+-   `Unwind.return`
+-   `Unwind.remove`
+-   `Unwind.set`

--- a/src/clauses/Unwind.test.ts
+++ b/src/clauses/Unwind.test.ts
@@ -43,6 +43,27 @@ describe("CypherBuilder Unwind", () => {
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
 
+    test("Unwind with set, remove and delete", () => {
+        const variable = new Cypher.Variable();
+        const unwindQuery = new Cypher.Unwind([new Cypher.Variable(), variable])
+            .set([variable.property("title"), new Cypher.Param("The Matrix")])
+            .remove(variable.property("title"))
+            .delete(variable);
+        const queryResult = unwindQuery.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"UNWIND var0 AS var1
+SET
+    var1.title = $param0
+REMOVE var1.title
+DELETE var1"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`
+{
+  "param0": "The Matrix",
+}
+`);
+    });
+
     test("Chained Unwind", () => {
         const variable = new Cypher.Variable();
         const unwindQuery = new Cypher.Unwind([new Cypher.Variable(), variable]).unwind([

--- a/tests/clause-concatenation.test.ts
+++ b/tests/clause-concatenation.test.ts
@@ -134,11 +134,9 @@ describe("Clause chaining", () => {
         const clause = new Cypher.Unwind();
 
         it.each([
-            // "where",
-            // "and",
-            // "return",
-            // "remove",
-            // "set",
+            "return",
+            "remove",
+            "set",
             "delete",
             "detachDelete",
             "with",
@@ -147,10 +145,6 @@ describe("Clause chaining", () => {
             "optionalMatch",
             // "merge",
             // "create",
-            // "assignToPath",
-            // "orderBy",
-            // "skip",
-            // "limit",
         ] as const)("Unwind.%s", (value) => {
             expect(clause[value]).toBeFunction();
         });


### PR DESCRIPTION

Add support for chained clauses in unwind:

-   `Unwind.return`
-   `Unwind.remove`
-   `Unwind.set`