### PR TITLE
Support for passing undefined to where

### DIFF
--- a/.changeset/tough-parrots-rhyme.md
+++ b/.changeset/tough-parrots-rhyme.md
@@ -1,0 +1,19 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Support for passing `undefined` to `.where`:
+
+```ts
+const n = new Cypher.Node();
+new Cypher.Match(n).where(undefined).return(n);
+```
+
+This will generate the following Cypher:
+
+```
+MATCH(n)
+RETURN n
+```
+
+Note that the `WHERE` clause is omitted if the predicate is `undefined`

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import type { Predicate } from "..";
 import Cypher from "..";
 
 describe("CypherBuilder Match", () => {
@@ -425,6 +426,45 @@ describe("CypherBuilder Match", () => {
                 "MATCH (this0:Movie)
                 RETURN this0"
             `);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("Match where with undefined predicate", () => {
+            const movieNode = new Cypher.Node({
+                labels: ["Movie"],
+            });
+
+            const maybePredicate: Predicate | undefined = undefined;
+
+            const matchQuery = new Cypher.Match(movieNode).where(maybePredicate).return(movieNode);
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+RETURN this0"
+`);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+        test("Match where ... and with undefined predicate", () => {
+            const movieNode = new Cypher.Node({
+                labels: ["Movie"],
+            });
+
+            const maybePredicate: Predicate | undefined = undefined;
+
+            const matchQuery = new Cypher.Match(movieNode)
+                .where(Cypher.eq(new Cypher.Variable(), new Cypher.Variable()))
+                .and(maybePredicate)
+                .return(movieNode);
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE var1 = var2
+RETURN this0"
+`);
 
             expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });

--- a/src/clauses/mixins/sub-clauses/WithWhere.ts
+++ b/src/clauses/mixins/sub-clauses/WithWhere.ts
@@ -29,7 +29,6 @@ import { Where } from "../../sub-clauses/Where";
 import { Mixin } from "../Mixin";
 
 export type VariableLike = Variable | Literal | PropertyRef;
-type VariableWithProperties = Variable | PropertyRef;
 
 export abstract class WithWhere extends Mixin {
     protected whereSubClause: Where | undefined;
@@ -38,31 +37,29 @@ export abstract class WithWhere extends Mixin {
      * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/where/)
      */
     public where(input: Predicate | undefined): this;
-    public where(target: VariableWithProperties, params: Record<string, VariableLike>): this;
-    public where(input: Predicate | VariableWithProperties | undefined, params?: Record<string, VariableLike>): this {
-        if (input) {
-            this.updateOrCreateWhereClause(input, params);
-        }
+    public where(target: Variable | PropertyRef, params: Record<string, VariableLike>): this;
+    public where(input: Predicate | Variable | PropertyRef | undefined, params?: Record<string, VariableLike>): this {
+        this.updateOrCreateWhereClause(input, params);
         return this;
     }
 
     /** Shorthand for `AND` operation after a `WHERE` subclause
      */
     public and(input: Predicate | undefined): this;
-    public and(target: VariableWithProperties, params: Record<string, VariableLike>): this;
-    public and(input: Predicate | VariableWithProperties | undefined, params?: Record<string, VariableLike>): this {
-        if (input) {
-            this.updateOrCreateWhereClause(input, params);
-        }
+    public and(target: Variable | PropertyRef, params: Record<string, VariableLike>): this;
+    public and(input: Predicate | Variable | PropertyRef | undefined, params?: Record<string, VariableLike>): this {
+        this.updateOrCreateWhereClause(input, params);
         return this;
     }
 
     private updateOrCreateWhereClause(
-        input: Predicate | VariableWithProperties,
+        input: Predicate | Variable | PropertyRef | undefined,
         params?: Record<string, VariableLike>
     ): void {
         const whereInput = this.createWhereInput(input, params);
-        if (!whereInput) return;
+        if (!whereInput) {
+            return;
+        }
 
         if (!this.whereSubClause) {
             const whereClause = new Where(this, whereInput);
@@ -73,9 +70,12 @@ export abstract class WithWhere extends Mixin {
     }
 
     private createWhereInput(
-        input: Predicate | Variable | PropertyRef,
+        input: Predicate | Variable | PropertyRef | undefined,
         params: Record<string, VariableLike> | undefined
     ): Predicate | undefined {
+        if (!input) {
+            return undefined;
+        }
         if (input instanceof Variable || input instanceof PropertyRef) {
             const generatedOp = this.variableAndObjectToOperation(input, params ?? {});
             return generatedOp;

--- a/src/clauses/mixins/sub-clauses/WithWhere.ts
+++ b/src/clauses/mixins/sub-clauses/WithWhere.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
-import { Where } from "../../sub-clauses/Where";
 import type { BooleanOp } from "../../../expressions/operations/boolean";
 import { and } from "../../../expressions/operations/boolean";
-import { PropertyRef } from "../../../references/PropertyRef";
 import type { ComparisonOp } from "../../../expressions/operations/comparison";
 import { eq } from "../../../expressions/operations/comparison";
-import type { Predicate } from "../../../types";
-import { Variable } from "../../../references/Variable";
 import type { Literal } from "../../../references/Literal";
+import { PropertyRef } from "../../../references/PropertyRef";
+import { Variable } from "../../../references/Variable";
+import type { Predicate } from "../../../types";
+import { Where } from "../../sub-clauses/Where";
 import { Mixin } from "../Mixin";
 
 export type VariableLike = Variable | Literal | PropertyRef;
@@ -37,19 +37,23 @@ export abstract class WithWhere extends Mixin {
     /** Add a `WHERE` subclause
      * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/where/)
      */
-    public where(input: Predicate): this;
+    public where(input: Predicate | undefined): this;
     public where(target: VariableWithProperties, params: Record<string, VariableLike>): this;
-    public where(input: Predicate | VariableWithProperties, params?: Record<string, VariableLike>): this {
-        this.updateOrCreateWhereClause(input, params);
+    public where(input: Predicate | VariableWithProperties | undefined, params?: Record<string, VariableLike>): this {
+        if (input) {
+            this.updateOrCreateWhereClause(input, params);
+        }
         return this;
     }
 
     /** Shorthand for `AND` operation after a `WHERE` subclause
      */
-    public and(input: Predicate): this;
+    public and(input: Predicate | undefined): this;
     public and(target: VariableWithProperties, params: Record<string, VariableLike>): this;
-    public and(input: Predicate | VariableWithProperties, params?: Record<string, VariableLike>): this {
-        this.updateOrCreateWhereClause(input, params);
+    public and(input: Predicate | VariableWithProperties | undefined, params?: Record<string, VariableLike>): this {
+        if (input) {
+            this.updateOrCreateWhereClause(input, params);
+        }
         return this;
     }
 


### PR DESCRIPTION
Support for passing `undefined` to `.where`:

```ts
const n = new Cypher.Node();
new Cypher.Match(n).where(undefined).return(n);
```

This will generate the following Cypher:

```
MATCH(n)
RETURN n
```

Note that the `WHERE` clause is omitted if the predicate is `undefined`