### PR TITLE
Add support for nested .yield

### DIFF
--- a/.changeset/popular-needles-share.md
+++ b/.changeset/popular-needles-share.md
@@ -1,0 +1,21 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Support for chained `.yield`:
+
+```ts
+const customProcedure = new Cypher.Procedure("customProcedure", []).yield("result1").yield(["result2", "aliased"]);
+```
+
+is equivalent to:
+
+```ts
+const customProcedure = new Cypher.Procedure("customProcedure", []).yield("result1", ["result2", "aliased"]);
+```
+
+and results in the Cypher:
+
+```cypher
+CALL customProcedure() YIELD result1, result2 AS aliased
+```

--- a/src/procedures/CypherProcedure.test.ts
+++ b/src/procedures/CypherProcedure.test.ts
@@ -88,4 +88,15 @@ describe("Procedures", () => {
         expect(cypher).toMatchInlineSnapshot(`"CALL customProcedure(this0)"`);
         expect(params).toMatchInlineSnapshot(`{}`);
     });
+
+    test("Custom Procedure with chained yield", () => {
+        const customProcedure = new Cypher.Procedure<"result1" | "result2">("customProcedure")
+            .yield("result1")
+            .yield(["result2", "aliased"]);
+
+        const { cypher, params } = customProcedure.build();
+
+        expect(cypher).toMatchInlineSnapshot(`"CALL customProcedure() YIELD result1, result2 AS aliased"`);
+        expect(params).toMatchInlineSnapshot(`{}`);
+    });
 });

--- a/src/procedures/CypherProcedure.ts
+++ b/src/procedures/CypherProcedure.ts
@@ -62,9 +62,9 @@ export class VoidCypherProcedure extends Clause {
  * @group Procedures
  */
 export class CypherProcedure<T extends string = string> extends VoidCypherProcedure {
-    private yieldStatement: Yield | undefined;
+    private yieldStatement: Yield<T> | undefined;
 
-    public yield(...columns: Array<"*" | YieldProjectionColumn<T>>): Yield {
+    public yield(...columns: Array<"*" | YieldProjectionColumn<T>>): Yield<T> {
         if (columns.length === 0) throw new Error("Empty projection in CALL ... YIELD");
         this.yieldStatement = new Yield(columns);
         this.addChildren(this.yieldStatement);

--- a/src/procedures/Yield.ts
+++ b/src/procedures/Yield.ts
@@ -41,14 +41,19 @@ export interface Yield extends WithReturn, WithWhere, WithWith {}
  * @group Procedures
  */
 @mixin(WithReturn, WithWhere, WithWith)
-export class Yield extends Clause {
+export class Yield<T extends string = string> extends Clause {
     private projection: YieldProjection;
 
-    constructor(yieldColumns: Array<YieldProjectionColumn<string>>) {
+    constructor(yieldColumns: Array<YieldProjectionColumn<T>>) {
         super();
 
         const columns = asArray(yieldColumns);
         this.projection = new YieldProjection(columns);
+    }
+
+    public yield(...columns: Array<YieldProjectionColumn<T>>): this {
+        this.projection.addYieldColumns(columns);
+        return this;
     }
 
     /** @internal */
@@ -67,6 +72,10 @@ export class Yield extends Clause {
 export class YieldProjection extends Projection {
     constructor(columns: Array<YieldProjectionColumn<string>>) {
         super([]);
+        this.addYieldColumns(columns);
+    }
+
+    public addYieldColumns(columns: Array<YieldProjectionColumn<string>>) {
         const parsedColumns = columns.map((c) => this.parseYieldColumn(c));
         this.addColumns(parsedColumns);
     }


### PR DESCRIPTION
Support for chained `.yield`:

```ts
const customProcedure = new Cypher.Procedure("customProcedure", []).yield("result1").yield(["result2", "aliased"]);
```

is equivalent to:

```ts
const customProcedure = new Cypher.Procedure("customProcedure", []).yield("result1", ["result2", "aliased"]);
```

and results in the Cypher:

```cypher
CALL customProcedure() YIELD result1, result2 AS aliased
```