### PR TITLE
Fix typings for binary operations

### DIFF
--- a/.changeset/fuzzy-pans-move.md
+++ b/.changeset/fuzzy-pans-move.md
@@ -1,0 +1,28 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Fix typings for boolean operators such as `Cypher.and`.
+
+Until now, binary boolean operators (`and`, `or` and `xor`) could return undefined, this made it very easy for the typings to be incorrect, for example:
+
+```ts
+const predicates: Array<Cypher.Predicate> = [];
+const result = Cypher.and(...predicates); // result is undefined, but its type is Cypher.Predicate
+```
+
+To solve this, binary operations will always return a Predicate, which will translate to an empty string if the child predicates is empty.
+
+This means that binary operations can be used along with clauses expecting predicates without the need to check for undefined:
+
+```ts
+const n = new Cypher.Node();
+new Cypher.Match(n).where(Cypher.and(undefined)).return(n);
+```
+
+Will generate:
+
+```cypher
+MATCH (n)
+RETURN n
+```

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -447,6 +447,7 @@ RETURN this0"
 
             expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });
+
         test("Match where ... and with undefined predicate", () => {
             const movieNode = new Cypher.Node({
                 labels: ["Movie"],
@@ -463,6 +464,24 @@ RETURN this0"
             expect(queryResult.cypher).toMatchInlineSnapshot(`
 "MATCH (this0:Movie)
 WHERE var1 = var2
+RETURN this0"
+`);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("Match where with undefined predicate inside boolean operation", () => {
+            const movieNode = new Cypher.Node({
+                labels: ["Movie"],
+            });
+
+            const maybePredicate: Predicate = Cypher.and(undefined);
+
+            const matchQuery = new Cypher.Match(movieNode).where(maybePredicate).return(movieNode);
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
 RETURN this0"
 `);
 

--- a/src/clauses/mixins/sub-clauses/WithWhere.ts
+++ b/src/clauses/mixins/sub-clauses/WithWhere.ts
@@ -17,9 +17,7 @@
  * limitations under the License.
  */
 
-import type { BooleanOp } from "../../../expressions/operations/boolean";
 import { and } from "../../../expressions/operations/boolean";
-import type { ComparisonOp } from "../../../expressions/operations/comparison";
 import { eq } from "../../../expressions/operations/comparison";
 import type { Literal } from "../../../references/Literal";
 import { PropertyRef } from "../../../references/PropertyRef";
@@ -87,8 +85,8 @@ export abstract class WithWhere extends Mixin {
     private variableAndObjectToOperation(
         target: Variable | PropertyRef,
         params: Record<string, VariableLike>
-    ): BooleanOp | ComparisonOp | undefined {
-        let operation: BooleanOp | ComparisonOp | undefined;
+    ): Predicate | undefined {
+        let operation: Predicate | undefined;
         for (const [key, value] of Object.entries(params)) {
             const property = target.property(key);
             const eqOp = eq(property, value);

--- a/tests/clause-concatenation.test.ts
+++ b/tests/clause-concatenation.test.ts
@@ -111,7 +111,6 @@ describe("Clause chaining", () => {
             "detachDelete",
             "with",
             "merge",
-
             "create",
             "assignToPath",
         ] as const)("Merge.%s", (value) => {


### PR DESCRIPTION

Fix typings for boolean operators such as `Cypher.and`.

Until now, binary boolean operators (`and`, `or` and `xor`) could return undefined, this made it very easy for the typings to be incorrect, for example:

```ts
const predicates: Array<Cypher.Predicate> = [];
const result = Cypher.and(...predicates); // result is undefined, but its type is Cypher.Predicate
```

To solve this, binary operations will always return a Predicate, which will translate to an empty string if the child predicates is empty.

This means that binary operations can be used along with clauses expecting predicates without the need to check for undefined:

```ts
const n = new Cypher.Node();
new Cypher.Match(n).where(Cypher.and(undefined)).return(n);
```

Will generate:

```cypher
MATCH (n)
RETURN n
```