### PR TITLE
Fix ordering of set and onCreate

### DIFF
--- a/.changeset/sixty-poems-float.md
+++ b/.changeset/sixty-poems-float.md
@@ -1,0 +1,21 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Fix clauses order when using `Merge.onCreate` along with `.set`
+
+For example:
+
+```js
+const query = new Cypher.Merge(node)
+    .onCreate([node.property("age"), new Cypher.Param(23)])
+    .set([node.property("age"), new Cypher.Param(10)]);
+```
+
+```cypher
+MERGE (this0:MyLabel)
+ON CREATE SET
+    this0.age = $param1
+SET
+    this0.age = $param0
+```

--- a/src/clauses/Merge.test.ts
+++ b/src/clauses/Merge.test.ts
@@ -40,6 +40,31 @@ describe("CypherBuilder Merge", () => {
         `);
     });
 
+    test("Merge node with set and onCreate", () => {
+        const node = new Cypher.Node({
+            labels: ["MyLabel"],
+        });
+
+        const query = new Cypher.Merge(node)
+            .set([node.property("age"), new Cypher.Param(10)])
+            .onCreate([node.property("age"), new Cypher.Param(23)]);
+
+        const queryResult = query.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MERGE (this0:MyLabel)
+ON CREATE SET
+    this0.age = $param1
+SET
+    this0.age = $param0"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`
+{
+  "param0": 10,
+  "param1": 23,
+}
+`);
+    });
+
     test("Merge node onCreate with escaped property", () => {
         const node = new Cypher.Node({
             labels: ["MyLabel"],

--- a/src/clauses/Merge.ts
+++ b/src/clauses/Merge.ts
@@ -90,6 +90,6 @@ export class Merge extends Clause {
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
         const nextClause = this.compileNextClause(env);
 
-        return `${mergeStr}${setCypher}${onCreateCypher}${removeCypher}${deleteCypher}${nextClause}`;
+        return `${mergeStr}${onCreateCypher}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;
     }
 }


### PR DESCRIPTION
Fix case of using `MERGE ... ON CREATE SET` along with standalone `SET`.

The following query is not valid:

```
MERGE (this0:MyLabel)
SET
    this0.age = 10
ON CREATE SET
    this0.age = 20
```

And it is replace with the following accepted query:
```cypher
MERGE (this0:MyLabel)
ON CREATE SET
    this0.age = 20
SET
    this0.age = 10
```
