### PR TITLE
Deprecate Merge.onCreate in favor of Merge.onCreateSet

### DIFF
--- a/.changeset/rich-apes-jump.md
+++ b/.changeset/rich-apes-jump.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecate `Merge.onCreate` in favor of `Merge.onCreateSet` to better reflect the resulting Cypher `ON CREATE SET`

--- a/src/clauses/Merge.test.ts
+++ b/src/clauses/Merge.test.ts
@@ -204,7 +204,7 @@ DELETE this0"
             labels: ["MyLabel"],
         });
         const node2 = new Cypher.Node({
-            labels: ["MyLabel"],
+            labels: ["MyOtherLabel"],
         });
 
         const query = new Cypher.Merge(node1).merge(node2);
@@ -212,7 +212,7 @@ DELETE this0"
         const queryResult = query.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
 "MERGE (this0:MyLabel)
-MERGE (this1:MyLabel)"
+MERGE (this1:MyOtherLabel)"
 `);
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
@@ -222,7 +222,7 @@ MERGE (this1:MyLabel)"
             labels: ["MyLabel"],
         });
         const node2 = new Cypher.Node({
-            labels: ["MyLabel"],
+            labels: ["MyOtherLabel"],
         });
 
         const query = new Cypher.Merge(node1).merge(new Cypher.Merge(node2));
@@ -230,7 +230,7 @@ MERGE (this1:MyLabel)"
         const queryResult = query.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
 "MERGE (this0:MyLabel)
-MERGE (this1:MyLabel)"
+MERGE (this1:MyOtherLabel)"
 `);
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });

--- a/src/clauses/Merge.ts
+++ b/src/clauses/Merge.ts
@@ -56,7 +56,16 @@ export class Merge extends Clause {
         this.onCreateClause = new OnCreate(this);
     }
 
+    /**
+     * @deprecated Use {@link onCreateSet} instead
+     */
     public onCreate(...onCreateParams: OnCreateParam[]): this {
+        this.onCreateClause.addParams(...onCreateParams);
+
+        return this;
+    }
+
+    public onCreateSet(...onCreateParams: OnCreateParam[]): this {
         this.onCreateClause.addParams(...onCreateParams);
 
         return this;

--- a/src/clauses/Raw.ts
+++ b/src/clauses/Raw.ts
@@ -59,6 +59,6 @@ export class Raw extends Clause {
 
 /** Allows for a raw string to be used as a clause
  * @group Other
- * @deprecated use {@link Raw} instead
+ * @deprecated Use {@link Raw} instead
  */
 export class RawCypher extends Raw {}

--- a/tests/deprecated/on-create.test.ts
+++ b/tests/deprecated/on-create.test.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
-import Cypher from "..";
+import Cypher from "../../src";
 
 describe("CypherBuilder Merge", () => {
-    test("Merge node onCreateSet", () => {
+    test("Merge node onCreate", () => {
         const node = new Cypher.Node({
             labels: ["MyLabel"],
         });
 
-        const query = new Cypher.Merge(node).onCreateSet([node.property("age"), new Cypher.Param(23)]);
+        const query = new Cypher.Merge(node).onCreate([node.property("age"), new Cypher.Param(23)]);
 
         const queryResult = query.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
@@ -40,37 +40,12 @@ describe("CypherBuilder Merge", () => {
         `);
     });
 
-    test("Merge node with set and onCreate", () => {
-        const node = new Cypher.Node({
-            labels: ["MyLabel"],
-        });
-
-        const query = new Cypher.Merge(node)
-            .set([node.property("age"), new Cypher.Param(10)])
-            .onCreateSet([node.property("age"), new Cypher.Param(23)]);
-
-        const queryResult = query.build();
-        expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MERGE (this0:MyLabel)
-ON CREATE SET
-    this0.age = $param1
-SET
-    this0.age = $param0"
-`);
-        expect(queryResult.params).toMatchInlineSnapshot(`
-{
-  "param0": 10,
-  "param1": 23,
-}
-`);
-    });
-
     test("Merge node onCreate with escaped property", () => {
         const node = new Cypher.Node({
             labels: ["MyLabel"],
         });
 
-        const query = new Cypher.Merge(node).onCreateSet([node.property("$age"), new Cypher.Param(23)]);
+        const query = new Cypher.Merge(node).onCreate([node.property("$age"), new Cypher.Param(23)]);
 
         const queryResult = query.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
@@ -94,7 +69,7 @@ SET
             test: new Cypher.Param("test"),
         };
 
-        const query = new Cypher.Merge(new Cypher.Pattern(node).withProperties(nodeProps)).onCreateSet([
+        const query = new Cypher.Merge(new Cypher.Pattern(node).withProperties(nodeProps)).onCreate([
             node.property("age"),
             new Cypher.Param(23),
         ]);
@@ -122,7 +97,7 @@ SET
         const relationship = new Cypher.Relationship();
         const pattern = new Cypher.Pattern(node1).withoutLabels().related(relationship).to(node2);
         const query = new Cypher.Merge(pattern)
-            .onCreateSet(
+            .onCreate(
                 [node1.property("age"), new Cypher.Param(23)],
                 [node1.property("name"), new Cypher.Param("Keanu")],
                 [relationship.property("screentime"), new Cypher.Param(10)]
@@ -158,7 +133,7 @@ SET
         const path = new Cypher.Path();
         const query = new Cypher.Merge(pattern)
             .assignToPath(path)
-            .onCreateSet(
+            .onCreate(
                 [node1.property("age"), new Cypher.Param(23)],
                 [node1.property("name"), new Cypher.Param("Keanu")],
                 [relationship.property("screentime"), new Cypher.Param(10)]


### PR DESCRIPTION
This is done to avoid confusion when using the standalone `.set` method in `Merge` 