### PR TITLE
Add support for type filtering on relationships with hasType

### DIFF
--- a/.changeset/honest-clouds-visit.md
+++ b/.changeset/honest-clouds-visit.md
@@ -1,0 +1,14 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for type filtering on relationships
+
+```js
+new Cypher.Match(new Cypher.Pattern().related(new Cypher.Relationship()).to()).where(relationship.hasType("ACTED_IN"));
+```
+
+```cypher
+MATCH(this0)-[this1]->(this2)
+WHERE this1:ACTED_IN
+```

--- a/src/expressions/HasLabel.test.ts
+++ b/src/expressions/HasLabel.test.ts
@@ -22,34 +22,6 @@ import { TestClause } from "../utils/TestClause";
 import { HasLabel } from "./HasLabel";
 
 describe("HasLabel", () => {
-    test("Filtering with HasLabel", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
-        const query = new Cypher.Match(node).where(node.hasLabel("Movie"));
-
-        const queryResult = new TestClause(query).build();
-
-        expect(queryResult.cypher).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
-            WHERE this0:Movie"
-        `);
-
-        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
-    });
-
-    test("Filtering with multiple labels", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
-        const query = new Cypher.Match(node).where(node.hasLabels("Movie", "Film"));
-
-        const queryResult = new TestClause(query).build();
-
-        expect(queryResult.cypher).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
-            WHERE this0:Movie:Film"
-        `);
-
-        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
-    });
-
     test("Fails if no labels are provided", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
         expect(() => {
@@ -57,30 +29,96 @@ describe("HasLabel", () => {
         }).toThrow();
     });
 
-    test("HasLabel with label expression &", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
-        const query = new Cypher.Match(node).where(node.hasLabel(Cypher.labelExpr.and("Movie", "Film")));
+    describe("node.hasLabel", () => {
+        test("Filtering with HasLabel", () => {
+            const node = new Cypher.Node({ labels: ["Movie"] });
+            const query = new Cypher.Match(node).where(node.hasLabel("Movie"));
 
-        const queryResult = new TestClause(query).build();
+            const queryResult = new TestClause(query).build();
 
-        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            WHERE this0:Movie"
+        `);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("Filtering with multiple labels", () => {
+            const node = new Cypher.Node({ labels: ["Movie"] });
+            const query = new Cypher.Match(node).where(node.hasLabels("Movie", "Film"));
+
+            const queryResult = new TestClause(query).build();
+
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            WHERE this0:Movie:Film"
+        `);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("HasLabel with label expression &", () => {
+            const node = new Cypher.Node({ labels: ["Movie"] });
+            const query = new Cypher.Match(node).where(node.hasLabel(Cypher.labelExpr.and("Movie", "Film")));
+
+            const queryResult = new TestClause(query).build();
+
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
 "MATCH (this0:Movie)
 WHERE this0:(Movie&Film)"
 `);
 
-        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
-    });
-    test("HasLabel with label expression |", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
-        const query = new Cypher.Match(node).where(node.hasLabel(Cypher.labelExpr.or("Movie", "Film")));
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+        test("HasLabel with label expression |", () => {
+            const node = new Cypher.Node({ labels: ["Movie"] });
+            const query = new Cypher.Match(node).where(node.hasLabel(Cypher.labelExpr.or("Movie", "Film")));
 
-        const queryResult = new TestClause(query).build();
+            const queryResult = new TestClause(query).build();
 
-        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
 "MATCH (this0:Movie)
 WHERE this0:(Movie|Film)"
 `);
 
-        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+    });
+
+    describe("relationship.hasType", () => {
+        test("Filtering with hasType", () => {
+            const node = new Cypher.Node({ labels: ["Movie"] });
+            const relationship = new Cypher.Relationship();
+            const query = new Cypher.Match(new Cypher.Pattern(node).related(relationship).to()).where(
+                relationship.hasType("ACTED_IN")
+            );
+
+            const queryResult = new TestClause(query).build();
+
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)-[this1]->(this2)
+WHERE this1:ACTED_IN"
+`);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("HasType with label expression |", () => {
+            const node = new Cypher.Node({ labels: ["Movie"] });
+            const relationship = new Cypher.Relationship({ type: "ACTED_IN" });
+            const query = new Cypher.Match(new Cypher.Pattern(node).related(relationship).to()).where(
+                relationship.hasType(Cypher.labelExpr.or("ACTED_IN", "STARRED_IN"))
+            );
+
+            const queryResult = new TestClause(query).build();
+
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)-[this1:ACTED_IN]->(this2)
+WHERE this1:(ACTED_IN|STARRED_IN)"
+`);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
     });
 });

--- a/src/expressions/HasLabel.ts
+++ b/src/expressions/HasLabel.ts
@@ -21,11 +21,12 @@ import type { LabelExpr } from "..";
 import { CypherASTNode } from "../CypherASTNode";
 import type { CypherEnvironment } from "../Environment";
 import type { NodeRef } from "../references/NodeRef";
+import type { RelationshipRef } from "../references/RelationshipRef";
 import { addLabelToken } from "../utils/add-label-token";
 import { escapeLabel } from "../utils/escape";
 
-/** Generates a predicate to check if a node has a label
- * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/expressions/#existential-subqueries)
+/** Generates a predicate to check if a node has a label or a relationship has a type
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/where/#filter-on-node-label)
  * @group Other
  * @example
  * ```cypher
@@ -34,13 +35,13 @@ import { escapeLabel } from "../utils/escape";
  * ```
  */
 export class HasLabel extends CypherASTNode {
-    private node: NodeRef;
+    private node: NodeRef | RelationshipRef;
     private expectedLabels: string[] | LabelExpr;
 
     /**
      * @hidden
      */
-    constructor(node: NodeRef, expectedLabels: string[] | LabelExpr) {
+    constructor(node: NodeRef | RelationshipRef, expectedLabels: string[] | LabelExpr) {
         super();
         this.validateLabelsInput(expectedLabels);
         this.node = node;

--- a/src/references/RelationshipRef.ts
+++ b/src/references/RelationshipRef.ts
@@ -17,8 +17,9 @@
  * limitations under the License.
  */
 
-import type { Expr } from "..";
+import { HasLabel } from "../expressions/HasLabel";
 import type { LabelExpr } from "../expressions/labels/label-expressions";
+import type { Expr } from "../types";
 import type { NodeRef } from "./NodeRef";
 import type { NamedReference } from "./Variable";
 import { Variable } from "./Variable";
@@ -45,6 +46,14 @@ export class RelationshipRef extends Variable {
         super();
         this.prefix = "this";
         this._type = input.type ?? undefined;
+    }
+
+    public hasType(label: string | LabelExpr): HasLabel {
+        if (typeof label === "string") {
+            return new HasLabel(this, [label]);
+        } else {
+            return new HasLabel(this, label);
+        }
     }
 
     public get type(): string | LabelExpr | undefined {


### PR DESCRIPTION
Add support for type filtering on relationships

```js
new Cypher.Match(new Cypher.Pattern().related(new Cypher.Relationship()).to()).where(relationship.hasType("ACTED_IN"));
```

```cypher
MATCH(this0)-[this1]->(this2)
WHERE this1:ACTED_IN
```