### PR TITLE
Support for ON MATCH SET

### DIFF
--- a/.changeset/wise-bags-tease.md
+++ b/.changeset/wise-bags-tease.md
@@ -1,0 +1,24 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for `ON MATCH SET` after `MERGE`:
+
+```js
+const node = new Cypher.Node({
+    labels: ["MyLabel"],
+});
+
+const countProp = node.property("count");
+const query = new Cypher.Merge(node)
+    .onCreateSet([countProp, new Cypher.Literal(1)])
+    .onMatchSet([countProp, Cypher.plus(countProp, new Cypher.Literal(1))]);
+```
+
+```cypher
+MERGE (this0:MyLabel)
+ON MATCH SET
+    this0.count = (this0.count + 1)
+ON CREATE SET
+    this0.count = 1
+```

--- a/src/clauses/Merge.test.ts
+++ b/src/clauses/Merge.test.ts
@@ -234,4 +234,45 @@ MERGE (this1:MyOtherLabel)"
 `);
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
+
+    test("Merge node onMatchSet", () => {
+        const node = new Cypher.Node({
+            labels: ["MyLabel"],
+        });
+
+        const query = new Cypher.Merge(node).onMatchSet([node.property("age"), new Cypher.Param(23)]);
+
+        const queryResult = query.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "MERGE (this0:MyLabel)
+            ON MATCH SET
+                this0.age = $param0"
+        `);
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": 23,
+            }
+        `);
+    });
+
+    test("Merge node with onMatch and onCreate", () => {
+        const node = new Cypher.Node({
+            labels: ["MyLabel"],
+        });
+
+        const countProp = node.property("count");
+        const query = new Cypher.Merge(node)
+            .onCreateSet([countProp, new Cypher.Literal(1)])
+            .onMatchSet([countProp, Cypher.plus(countProp, new Cypher.Literal(1))]);
+
+        const queryResult = query.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MERGE (this0:MyLabel)
+ON MATCH SET
+    this0.count = (this0.count + 1)
+ON CREATE SET
+    this0.count = 1"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
 });

--- a/src/clauses/Merge.ts
+++ b/src/clauses/Merge.ts
@@ -31,6 +31,7 @@ import { WithRemove } from "./mixins/sub-clauses/WithRemove";
 import { WithSet } from "./mixins/sub-clauses/WithSet";
 import type { OnCreateParam } from "./sub-clauses/OnCreate";
 import { OnCreate } from "./sub-clauses/OnCreate";
+import { OnMatch } from "./sub-clauses/OnMatch";
 import { mixin } from "./utils/mixin";
 
 export interface Merge extends WithReturn, WithSet, WithPathAssign, WithDelete, WithRemove, WithWith, WithCreate {}
@@ -43,6 +44,7 @@ export interface Merge extends WithReturn, WithSet, WithPathAssign, WithDelete, 
 export class Merge extends Clause {
     private pattern: Pattern;
     private onCreateClause: OnCreate;
+    private onMatchClause: OnMatch;
 
     constructor(pattern: NodeRef | Pattern) {
         super();
@@ -54,6 +56,7 @@ export class Merge extends Clause {
         }
 
         this.onCreateClause = new OnCreate(this);
+        this.onMatchClause = new OnMatch(this);
     }
 
     /**
@@ -67,7 +70,11 @@ export class Merge extends Clause {
 
     public onCreateSet(...onCreateParams: OnCreateParam[]): this {
         this.onCreateClause.addParams(...onCreateParams);
+        return this;
+    }
 
+    public onMatchSet(...onMatchParams: OnCreateParam[]): this {
+        this.onMatchClause.addParams(...onMatchParams);
         return this;
     }
 
@@ -95,10 +102,11 @@ export class Merge extends Clause {
         const mergeStr = `MERGE ${pathAssignStr}${this.pattern.getCypher(env)}`;
         const setCypher = compileCypherIfExists(this.setSubClause, env, { prefix: "\n" });
         const onCreateCypher = compileCypherIfExists(this.onCreateClause, env, { prefix: "\n" });
+        const onMatchCypher = compileCypherIfExists(this.onMatchClause, env, { prefix: "\n" });
         const deleteCypher = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
         const nextClause = this.compileNextClause(env);
 
-        return `${mergeStr}${onCreateCypher}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;
+        return `${mergeStr}${onMatchCypher}${onCreateCypher}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;
     }
 }

--- a/src/clauses/sub-clauses/OnMatch.ts
+++ b/src/clauses/sub-clauses/OnMatch.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CypherEnvironment } from "../../Environment";
+import type { SetParam } from "./Set";
+import { SetClause } from "./Set";
+
+export type OnMatchParam = SetParam;
+
+export class OnMatch extends SetClause {
+    /** @internal */
+    public getCypher(env: CypherEnvironment): string {
+        if (this.params.length === 0) return "";
+        const setCypher = super.getCypher(env);
+        return `ON MATCH ${setCypher}`;
+    }
+}


### PR DESCRIPTION
Add support for `ON MATCH SET` after `MERGE`:

```js
const node = new Cypher.Node({
    labels: ["MyLabel"],
});

const countProp = node.property("count");
const query = new Cypher.Merge(node)
    .onCreateSet([countProp, new Cypher.Literal(1)])
    .onMatchSet([countProp, Cypher.plus(countProp, new Cypher.Literal(1))]);
```

```cypher
MERGE (this0:MyLabel)
ON MATCH SET
    this0.count = (this0.count + 1)
ON CREATE SET
    this0.count = 1
```