### PR TITLE
Add prettierignore and removes CHANGELOG from prettier workflow

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "lint": "eslint .",
         "changeset": "changeset",
         "release": "npm run build && changeset publish",
-        "prettier": "prettier . --check --ignore-path .gitignore"
+        "prettier": "prettier . --check"
     },
     "repository": {
         "type": "git",


### PR DESCRIPTION
Changelog.md is autogenerated, so it doesn't make sense to run prettier on it as there are conflicts with changeset