### PR TITLE
Add labelOperator option

### DIFF
--- a/.changeset/wet-worms-drum.md
+++ b/.changeset/wet-worms-drum.md
@@ -1,0 +1,24 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Add `labelOperator` option on build to change the default label `AND` operator:
+
+```js
+const node = new Cypher.Node({ labels: ["Movie", "Film"] });
+const query = new Cypher.Match(node);
+
+const queryResult = new TestClause(query).build(
+    undefined,
+    {},
+    {
+        labelOperator: "&",
+    }
+);
+```
+
+Will return:
+
+```cypher
+MATCH (this:Movie&Film)
+```

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -150,7 +150,7 @@ export * as db from "./namespaces/db/db";
 
 // Types
 export type { CypherEnvironment as Environment } from "./Environment";
-export type { Clause } from "./clauses/Clause";
+export type { BuildConfig, Clause } from "./clauses/Clause";
 export type { Order } from "./clauses/sub-clauses/OrderBy";
 export type { ProjectionColumn } from "./clauses/sub-clauses/Projection";
 export type { SetParam } from "./clauses/sub-clauses/Set";

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -27,6 +27,14 @@ export type EnvPrefix = {
     variables?: string;
 };
 
+export type EnvConfig = {
+    labelOperator: ":" | "&";
+};
+
+const defaultConfig: EnvConfig = {
+    labelOperator: ":",
+};
+
 /** Hold the internal references of Cypher parameters and variables
  *  @group Internal
  */
@@ -36,10 +44,12 @@ export class CypherEnvironment {
     private references: Map<Variable, string> = new Map();
     private params: Param[] = [];
 
+    public readonly config: EnvConfig;
+
     /**
      *  @internal
      */
-    constructor(prefix?: string | EnvPrefix) {
+    constructor(prefix?: string | EnvPrefix, config: Partial<EnvConfig> = {}) {
         if (!prefix || typeof prefix === "string") {
             this.globalPrefix = {
                 params: prefix ?? "",
@@ -51,6 +61,11 @@ export class CypherEnvironment {
                 variables: prefix.variables ?? "",
             };
         }
+
+        this.config = {
+            ...defaultConfig,
+            ...config,
+        };
     }
 
     public compile(element: CypherCompilable): string {

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -18,7 +18,7 @@
  */
 
 import { CypherASTNode } from "../CypherASTNode";
-import type { EnvPrefix } from "../Environment";
+import type { EnvConfig, EnvPrefix } from "../Environment";
 import { CypherEnvironment } from "../Environment";
 import type { CypherResult } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
@@ -27,6 +27,9 @@ import { toCypherParams } from "../utils/to-cypher-params";
 
 const customInspectSymbol = Symbol.for("nodejs.util.inspect.custom");
 
+/** Config fields for the .build method */
+export type BuildConfig = Partial<EnvConfig>;
+
 /** Represents a clause AST node
  *  @group Internal
  */
@@ -34,9 +37,13 @@ export abstract class Clause extends CypherASTNode {
     protected nextClause: Clause | undefined;
 
     /** Compiles a clause into Cypher and params */
-    public build(prefix?: string | EnvPrefix | undefined, extraParams: Record<string, unknown> = {}): CypherResult {
+    public build(
+        prefix?: string | EnvPrefix | undefined,
+        extraParams: Record<string, unknown> = {},
+        config?: BuildConfig
+    ): CypherResult {
         if (this.isRoot) {
-            const env = this.getEnv(prefix);
+            const env = this.getEnv(prefix, config);
             const cypher = this.getCypher(env);
 
             const cypherParams = toCypherParams(extraParams);
@@ -53,8 +60,8 @@ export abstract class Clause extends CypherASTNode {
         throw new Error(`Cannot build root: ${root.constructor.name}`);
     }
 
-    private getEnv(prefix?: string | EnvPrefix): CypherEnvironment {
-        return new CypherEnvironment(prefix);
+    private getEnv(prefix?: string | EnvPrefix, config: BuildConfig = {}): CypherEnvironment {
+        return new CypherEnvironment(prefix, config);
     }
 
     /** Custom string for browsers and templating

--- a/src/expressions/HasLabel.ts
+++ b/src/expressions/HasLabel.ts
@@ -58,9 +58,9 @@ export class HasLabel extends CypherASTNode {
     private generateLabelExpressionStr(env: CypherEnvironment): string {
         if (Array.isArray(this.expectedLabels)) {
             const escapedLabels = this.expectedLabels.map((label) => escapeLabel(label));
-            return addLabelToken(...escapedLabels);
+            return addLabelToken(env.config.labelOperator, ...escapedLabels);
         } else {
-            return addLabelToken(this.expectedLabels.getCypher(env));
+            return addLabelToken(env.config.labelOperator, this.expectedLabels.getCypher(env));
         }
     }
 

--- a/src/pattern/Pattern.ts
+++ b/src/pattern/Pattern.ts
@@ -91,13 +91,13 @@ export class Pattern extends PatternElement<NodeRef> {
             if (!labelsStr) {
                 return "";
             }
-            return addLabelToken(labels.getCypher(env));
+            return addLabelToken(env.config.labelOperator, labels.getCypher(env));
         } else {
             const escapedLabels = labels.map(escapeLabel);
             if (escapedLabels.length === 0) {
                 return "";
             }
-            return addLabelToken(...escapedLabels);
+            return addLabelToken(env.config.labelOperator, ...escapedLabels);
         }
     }
 }

--- a/src/utils/add-label-token.ts
+++ b/src/utils/add-label-token.ts
@@ -17,8 +17,11 @@
  * limitations under the License.
  */
 
-import { LABEL_TOKEN } from "../constants";
+export function addLabelToken(andToken: ":" | "&", ...labels: string[]): string {
+    const firstLabel = labels.shift();
+    if (!firstLabel) return "";
 
-export function addLabelToken(...labels: string[]): string {
-    return labels.map((label) => `${LABEL_TOKEN}${label}`).join("");
+    const extraLabels = labels.map((label) => `${andToken}${label}`).join("");
+
+    return `:${firstLabel}${extraLabels}`;
 }

--- a/tests/config/labelOperator.test.ts
+++ b/tests/config/labelOperator.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../../src";
+import { TestClause } from "../../src/utils/TestClause";
+
+describe.each([":", "&"] as const)("Config.labelOperator", (labelOperator) => {
+    const config: Cypher.BuildConfig = {
+        labelOperator,
+    };
+
+    test("Pattern", () => {
+        const node = new Cypher.Node({ labels: ["Movie", "Film"] });
+        const query = new Cypher.Match(node);
+
+        const queryResult = new TestClause(query).build(undefined, {}, config);
+
+        expect(queryResult.cypher).toBe(`MATCH (this0:Movie${labelOperator}Film)`);
+    });
+
+    test("hasLabel", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+        const query = new Cypher.Match(node).where(node.hasLabels("Movie", "Film"));
+
+        const queryResult = new TestClause(query).build(undefined, {}, config);
+
+        expect(queryResult.cypher).toBe(`MATCH (this0:Movie)
+WHERE this0:Movie${labelOperator}Film`);
+    });
+});


### PR DESCRIPTION
Add `labelOperator` option on build to change the default label `AND` operator:

```js
const node = new Cypher.Node({ labels: ["Movie", "Film"] });
const query = new Cypher.Match(node);

const queryResult = new TestClause(query).build(
    undefined,
    {},
    {
        labelOperator: "&",
    }
);
```

Will return:

```cypher
MATCH (this:Movie&Film)
```

Instead of the default:

```cypher
MATCH (this:Movie:Film)
```

This is needed to keep support with Cypher 5 and logical label operators (More info in #248).

For next breaking version of Cypher Builder, all config passed to `.build` should be in the same object 
