### PR TITLE
78 type predicate expressions

### DIFF
--- a/.changeset/purple-queens-warn.md
+++ b/.changeset/purple-queens-warn.md
@@ -1,0 +1,18 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for type predicate expressions with the functions `Cypher.isType` and `Cypher.isNotType`:
+
+```ts
+const variable = new Cypher.Variable();
+const unwindClause = new Cypher.Unwind([new Cypher.Literal([42, true, "abc", null]), variable]).return(
+    variable,
+    Cypher.isType(variable, Cypher.TYPE.INTEGER)
+);
+```
+
+```cypher
+UNWIND [42, true, \\"abc\\", NULL] AS var0
+RETURN var0, var0 IS :: INTEGER
+```

--- a/docs/modules/ROOT/content-nav.adoc
+++ b/docs/modules/ROOT/content-nav.adoc
@@ -11,5 +11,6 @@
 * How-to guides
 ** xref:how-to/customize-cypher.adoc[]
 ** xref:how-to/use-change-data-capture.adoc[]
+** xref:how-to/type-predicate-expressions.adoc[]
 * link:https://github.com/neo4j/cypher-builder/tree/main/examples[Examples]
 * link:https://neo4j.github.io/cypher-builder/reference/[Reference]

--- a/docs/modules/ROOT/pages/how-to/type-predicate-expressions.adoc
+++ b/docs/modules/ROOT/pages/how-to/type-predicate-expressions.adoc
@@ -75,6 +75,18 @@ Cypher.isType(new Cypher.Variable(), Cypher.TYPE.list(Cypher.TYPE.STRING));
 var0 IS :: LIST<STRING>
 ----
 
+Union types can also be used within a list:
+
+[source, javascript]
+----
+Cypher.isType(new Cypher.Variable(), Cypher.TYPE.list([Cypher.TYPE.STRING, Cypher.TYPE.INTEGER]));
+----
+
+[source, cypher]
+----
+var0 IS :: LIST<STRING | INTEGER>
+----
+
 
 == Type predicate expressions with NOT
 
@@ -92,7 +104,7 @@ var0 IS NOT :: INTEGER
 
 == Type predicate expressions for non-nullable types
 
-Type predicate expressions evaluate to `true` in Cypher for `NULL` values, unless a `NOT NULL` is appended. In Cypher Builder, this can be achieved using the `.notNull` method:
+Type predicate expressions evaluate to `true` in Cypher for `NULL` values unless a `NOT NULL` is appended. In Cypher Builder, this can be achieved using the `.notNull` method:
 
 [source, javascript]
 ----
@@ -102,4 +114,16 @@ Cypher.isType(new Cypher.Variable(), Cypher.TYPE.INTEGER).notNull();
 [source, cypher]
 ----
 var0 IS :: INTEGER NOT NULL
+----
+
+Non-nullable types can also be used within a List type:
+
+[source, javascript]
+----
+Cypher.isType(new Cypher.Variable(), Cypher.TYPE.list(Cypher.TYPE.STRING).notNull());
+----
+
+[source, cypher]
+----
+var0 IS :: LIST<STRING NOT NULL>
 ----

--- a/docs/modules/ROOT/pages/how-to/type-predicate-expressions.adoc
+++ b/docs/modules/ROOT/pages/how-to/type-predicate-expressions.adoc
@@ -1,0 +1,105 @@
+[[type-predicate-expressions]]
+:description: This page describes how to build type predicate expressions.
+= Build Type Predicate Expressions
+
+This section outlines the process of creating link:https://neo4j.com/docs/cypher-manual/current/values-and-types/type-predicate/[type predicate expressions] within your queries using Cypher Builder.
+
+A type predicate expression serves to validate the type of a variable, literal, property, or another Cypher expression. It follows the syntax below in Cypher:
+
+[source, cypher]
+----
+<expr> IS :: <TYPE>
+----
+
+For example
+
+[source, cypher]
+----
+movie.title IS :: STRING
+----
+
+== `isType`
+
+Type predicate expressions can be constructed using `Cypher.isType` (distinct from the `.hasType` method in Relationship). The `isType` function takes a xref:variables-and-params.adoc[Cypher variable] and a type specified in `Cypher.TYPE`:
+
+[source, javascript]
+----
+Cypher.isType(new Cypher.Variable(), Cypher.TYPE.INTEGER);
+----
+
+[source, cypher]
+----
+var0 IS :: INTEGER
+----
+
+Type predicate expressions can be used in a `WHERE` statement, for example:
+
+[source, javascript]
+----
+const movie = new Cypher.Node({ labels: ["Movie"] });
+const matchClause = new Cypher.Match(movie).where(Cypher.isType(movie.property("title"), Cypher.TYPE.STRING)).return(movie);
+----
+
+[source, cypher]
+----
+MATCH (this0:Movie)
+WHERE this0.title IS :: STRING
+RETURN this0
+----
+
+=== Using Union types
+
+Union types, for example, `INTEGER | STRING`, can be used by passing an array to `.isType`:
+
+[source, javascript]
+----
+Cypher.isType(new Cypher.Variable(), [Cypher.TYPE.INTEGER, Cypher.TYPE.STRING]);
+----
+
+[source, cypher]
+----
+var0 IS :: INTEGER | STRING
+----
+
+=== List Types
+
+List types, for instance, `LIST<INTEGER>`, can be created using `Cypher.TYPES.list()`:
+
+[source, javascript]
+----
+Cypher.isType(new Cypher.Variable(), Cypher.TYPE.list(Cypher.TYPE.STRING));
+----
+
+[source, cypher]
+----
+var0 IS :: LIST<STRING>
+----
+
+
+== Type predicate expressions with NOT
+
+It is also possible to verify that a Cypher expression is not of a certain type with the function `Cypher.isNotType`:
+
+[source, javascript]
+----
+Cypher.isNotType(new Cypher.Variable(), Cypher.TYPE.INTEGER);
+----
+
+[source, cypher]
+----
+var0 IS NOT :: INTEGER
+----
+
+== Type predicate expressions for non-nullable types
+
+Type predicate expressions evaluate to `true` in Cypher for `NULL` values, unless a `NOT NULL` is appended. In Cypher Builder, this can be achieved using the `.notNull` method:
+
+[source, javascript]
+----
+Cypher.isType(new Cypher.Variable(), Cypher.TYPE.INTEGER).notNull();
+----
+
+[source, cypher]
+----
+var0 IS :: INTEGER NOT NULL
+----

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -47,6 +47,7 @@ export { NamedVariable, Variable } from "./references/Variable";
 
 // Expressions
 export { Case } from "./expressions/Case";
+export { CypherTypes as TYPE, isNotType, isType } from "./expressions/IsType";
 export { Count } from "./expressions/subquery/Count";
 export { Exists } from "./expressions/subquery/Exists";
 

--- a/src/expressions/IsType.test.ts
+++ b/src/expressions/IsType.test.ts
@@ -100,7 +100,7 @@ RETURN this0"
     test("isType with union type", () => {
         const movie = new Cypher.Node({ labels: ["Movie"] });
         const matchClause = new Cypher.Match(movie)
-            .where(Cypher.isType(movie.property("title"), Cypher.TYPE.list(Cypher.TYPE.STRING), Cypher.TYPE.STRING))
+            .where(Cypher.isType(movie.property("title"), [Cypher.TYPE.list(Cypher.TYPE.STRING), Cypher.TYPE.STRING]))
             .return(movie);
 
         const { cypher } = matchClause.build();
@@ -176,7 +176,7 @@ RETURN this0"
         test("isType.notNull with union type", () => {
             const movie = new Cypher.Node({ labels: ["Movie"] });
             const matchClause = new Cypher.Match(movie)
-                .where(Cypher.isType(movie.property("title"), Cypher.TYPE.STRING, Cypher.TYPE.BOOLEAN).notNull())
+                .where(Cypher.isType(movie.property("title"), [Cypher.TYPE.STRING, Cypher.TYPE.BOOLEAN]).notNull())
                 .return(movie);
 
             const { cypher } = matchClause.build();

--- a/src/expressions/IsType.test.ts
+++ b/src/expressions/IsType.test.ts
@@ -187,5 +187,25 @@ WHERE this0.title IS :: STRING NOT NULL | BOOLEAN NOT NULL
 RETURN this0"
 `);
         });
+
+        test("isType with union type", () => {
+            const movie = new Cypher.Node({ labels: ["Movie"] });
+            const matchClause = new Cypher.Match(movie)
+                .where(
+                    Cypher.isType(movie.property("title"), [
+                        Cypher.TYPE.list([Cypher.TYPE.STRING, Cypher.TYPE.FLOAT]).notNull(),
+                        Cypher.TYPE.STRING,
+                    ])
+                )
+                .return(movie);
+
+            const { cypher } = matchClause.build();
+
+            expect(cypher).toMatchInlineSnapshot(`
+    "MATCH (this0:Movie)
+    WHERE this0.title IS :: LIST<STRING NOT NULL | FLOAT NOT NULL> | STRING
+    RETURN this0"
+    `);
+        });
     });
 });

--- a/src/expressions/IsType.test.ts
+++ b/src/expressions/IsType.test.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "..";
+
+describe("IsType", () => {
+    test("UNWIND return isType", () => {
+        const variable = new Cypher.Variable();
+        const unwindClause = new Cypher.Unwind([new Cypher.Literal([42, true, "abc", null]), variable]).return(
+            variable,
+            Cypher.isType(variable, Cypher.TYPE.INTEGER)
+        );
+
+        const { cypher, params } = unwindClause.build();
+
+        expect(cypher).toMatchInlineSnapshot(`
+"UNWIND [42, true, \\"abc\\", NULL] AS var0
+RETURN var0, var0 IS :: INTEGER"
+`);
+        expect(params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test.each([
+        Cypher.TYPE.ANY,
+        Cypher.TYPE.BOOLEAN,
+        Cypher.TYPE.DATE,
+        Cypher.TYPE.DURATION,
+        Cypher.TYPE.FLOAT,
+        Cypher.TYPE.INTEGER,
+        Cypher.TYPE.LOCAL_DATETIME,
+        Cypher.TYPE.LOCAL_TIME,
+        Cypher.TYPE.MAP,
+        Cypher.TYPE.NODE,
+        Cypher.TYPE.NOTHING,
+        Cypher.TYPE.NULL,
+        Cypher.TYPE.PATH,
+        Cypher.TYPE.POINT,
+        Cypher.TYPE.PROPERTY_VALUE,
+        Cypher.TYPE.RELATIONSHIP,
+        Cypher.TYPE.STRING,
+        Cypher.TYPE.ZONED_DATETIME,
+        Cypher.TYPE.ZONED_TIME,
+    ] as const)("isType '%s'", (type) => {
+        const movie = new Cypher.Node({ labels: ["Movie"] });
+        const matchClause = new Cypher.Match(movie).where(Cypher.isType(movie.property("title"), type)).return(movie);
+
+        const { cypher } = matchClause.build();
+
+        expect(cypher).toEqual(`MATCH (this0:Movie)
+WHERE this0.title IS :: ${type}
+RETURN this0`);
+    });
+
+    test("isType 'List<STRING>'", () => {
+        const movie = new Cypher.Node({ labels: ["Movie"] });
+        const matchClause = new Cypher.Match(movie)
+            .where(Cypher.isType(movie.property("title"), Cypher.TYPE.list(Cypher.TYPE.STRING)))
+            .return(movie);
+
+        const { cypher } = matchClause.build();
+
+        expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE this0.title IS :: LIST<STRING>
+RETURN this0"
+`);
+    });
+
+    test("isType 'List<List<STRING>>'", () => {
+        const movie = new Cypher.Node({ labels: ["Movie"] });
+        const matchClause = new Cypher.Match(movie)
+            .where(Cypher.isType(movie.property("title"), Cypher.TYPE.list(Cypher.TYPE.list(Cypher.TYPE.STRING))))
+            .return(movie);
+
+        const { cypher } = matchClause.build();
+
+        expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE this0.title IS :: LIST<LIST<STRING>>
+RETURN this0"
+`);
+    });
+
+    test("isType with union type", () => {
+        const movie = new Cypher.Node({ labels: ["Movie"] });
+        const matchClause = new Cypher.Match(movie)
+            .where(Cypher.isType(movie.property("title"), Cypher.TYPE.list(Cypher.TYPE.STRING), Cypher.TYPE.STRING))
+            .return(movie);
+
+        const { cypher } = matchClause.build();
+
+        expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE this0.title IS :: LIST<STRING> | STRING
+RETURN this0"
+`);
+    });
+
+    test("isType in NOT", () => {
+        const movie = new Cypher.Node({ labels: ["Movie"] });
+        const matchClause = new Cypher.Match(movie)
+            .where(Cypher.not(Cypher.isType(movie.property("title"), Cypher.TYPE.STRING)))
+            .return(movie);
+
+        const { cypher } = matchClause.build();
+
+        expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE NOT (this0.title IS :: STRING)
+RETURN this0"
+`);
+    });
+
+    test("isNotType", () => {
+        const movie = new Cypher.Node({ labels: ["Movie"] });
+        const matchClause = new Cypher.Match(movie)
+            .where(Cypher.isNotType(movie.property("title"), Cypher.TYPE.STRING))
+            .return(movie);
+
+        const { cypher } = matchClause.build();
+
+        expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE this0.title IS NOT :: STRING
+RETURN this0"
+`);
+    });
+
+    describe("notNull", () => {
+        test("isType.notNull", () => {
+            const movie = new Cypher.Node({ labels: ["Movie"] });
+            const matchClause = new Cypher.Match(movie)
+                .where(Cypher.isType(movie.property("title"), Cypher.TYPE.STRING).notNull())
+                .return(movie);
+
+            const { cypher } = matchClause.build();
+
+            expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE this0.title IS :: STRING NOT NULL
+RETURN this0"
+`);
+        });
+
+        test("isNotType.notNull", () => {
+            const movie = new Cypher.Node({ labels: ["Movie"] });
+            const matchClause = new Cypher.Match(movie)
+                .where(Cypher.isNotType(movie.property("title"), Cypher.TYPE.STRING).notNull())
+                .return(movie);
+
+            const { cypher } = matchClause.build();
+
+            expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE this0.title IS NOT :: STRING NOT NULL
+RETURN this0"
+`);
+        });
+
+        test("isType.notNull with union type", () => {
+            const movie = new Cypher.Node({ labels: ["Movie"] });
+            const matchClause = new Cypher.Match(movie)
+                .where(Cypher.isType(movie.property("title"), Cypher.TYPE.STRING, Cypher.TYPE.BOOLEAN).notNull())
+                .return(movie);
+
+            const { cypher } = matchClause.build();
+
+            expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE this0.title IS :: STRING NOT NULL | BOOLEAN NOT NULL
+RETURN this0"
+`);
+        });
+    });
+});

--- a/src/expressions/IsType.ts
+++ b/src/expressions/IsType.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type Cypher from "..";
+import { CypherASTNode } from "../CypherASTNode";
+import type { ValueOf } from "../utils/type-helpers";
+
+const BaseTypes = {
+    ANY: "ANY",
+    BOOLEAN: "BOOLEAN",
+    DATE: "DATE",
+    DURATION: "DURATION",
+    FLOAT: "FLOAT",
+    INTEGER: "INTEGER",
+    LOCAL_DATETIME: "LOCAL DATETIME",
+    LOCAL_TIME: "LOCAL_TIME",
+    MAP: "MAP",
+    NODE: "NODE",
+    NOTHING: "NOTHING",
+    NULL: "NULL",
+    PATH: "PATH",
+    POINT: "POINT",
+    PROPERTY_VALUE: "PROPERTY VALUE",
+    RELATIONSHIP: "RELATIONSHIP",
+    STRING: "STRING",
+    ZONED_DATETIME: "ZONED DATETIME",
+    ZONED_TIME: "ZONED TIME",
+} as const;
+
+/**
+ * Generates a cypher LIST<...> type
+ * @example
+ * ```cypher
+ * LIST<STRING>
+ * ```
+ */
+function list(type: Type): ListType {
+    return new ListType(type);
+}
+
+/**
+ * Types supported by Neo4j
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/values-and-types/property-structural-constructed/#types-synonyms)
+ */
+export const CypherTypes = {
+    ...BaseTypes,
+    list,
+} as const;
+
+/**
+ * Type predicate expression
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/values-and-types/type-predicate/)
+ * @example
+ * ```cypher
+ * val IS :: INTEGER
+ * ```
+ */
+export function isType(expr: Cypher.Expr, ...type: Type[]): IsType {
+    return new IsType(expr, type);
+}
+
+/**
+ * Type predicate expression with NOT
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/values-and-types/type-predicate/#type-predicate-not)
+ * @example
+ * ```cypher
+ * val IS NOT :: INTEGER
+ * ```
+ */
+export function isNotType(expr: Cypher.Expr, ...type: Type[]): IsType {
+    return new IsType(expr, type, true);
+}
+
+class ListType {
+    private type: Type;
+
+    constructor(type: Type) {
+        this.type = type;
+    }
+
+    public getCypher(env: Cypher.Environment): string {
+        const typeStr = compileType(this.type, env);
+
+        return `LIST<${typeStr}>`;
+    }
+}
+
+export class IsType extends CypherASTNode {
+    private expr: Cypher.Expr;
+    private type: Type[];
+    private not: boolean;
+    private _notNull: boolean = false;
+
+    public constructor(expr: Cypher.Expr, type: Type[], not = false) {
+        super();
+        this.expr = expr;
+        this.type = type;
+        this.not = not;
+    }
+
+    public notNull(): this {
+        this._notNull = true;
+        return this;
+    }
+
+    public getCypher(env: Cypher.Environment): string {
+        const exprCypher = env.compile(this.expr);
+        const isStr = this.not ? "IS NOT" : "IS";
+
+        // Note that all types must be nullable or non nullable
+        const notNullStr = this._notNull ? " NOT NULL" : "";
+        const typesStr = this.type.map((type) => {
+            const typeStr = compileType(type, env);
+
+            return `${typeStr}${notNullStr}`;
+        });
+
+        return `${exprCypher} ${isStr} :: ${Array.from(typesStr).join(" | ")}`;
+    }
+}
+
+type Type = ValueOf<typeof BaseTypes> | ListType;
+
+function compileType(type: Type, env: Cypher.Environment): string {
+    if (type instanceof ListType) {
+        return env.compile(type);
+    } else {
+        return type;
+    }
+}

--- a/src/expressions/IsType.ts
+++ b/src/expressions/IsType.ts
@@ -19,6 +19,7 @@
 
 import type Cypher from "..";
 import { CypherASTNode } from "../CypherASTNode";
+import { asArray } from "../utils/as-array";
 import type { ValueOf } from "../utils/type-helpers";
 
 const BaseTypes = {
@@ -71,8 +72,8 @@ export const CypherTypes = {
  * val IS :: INTEGER
  * ```
  */
-export function isType(expr: Cypher.Expr, ...type: Type[]): IsType {
-    return new IsType(expr, type);
+export function isType(expr: Cypher.Expr, type: Type | Type[]): IsType {
+    return new IsType(expr, asArray(type));
 }
 
 /**
@@ -83,8 +84,8 @@ export function isType(expr: Cypher.Expr, ...type: Type[]): IsType {
  * val IS NOT :: INTEGER
  * ```
  */
-export function isNotType(expr: Cypher.Expr, ...type: Type[]): IsType {
-    return new IsType(expr, type, true);
+export function isNotType(expr: Cypher.Expr, type: Type | Type[]): IsType {
+    return new IsType(expr, asArray(type), true);
 }
 
 class ListType {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ import type { Raw, RawCypher } from ".";
 import type { CypherEnvironment } from "./Environment";
 import type { Case } from "./expressions/Case";
 import type { HasLabel } from "./expressions/HasLabel";
+import type { IsType } from "./expressions/IsType";
 import type { CypherFunction } from "./expressions/functions/CypherFunctions";
 import type { PredicateFunction } from "./expressions/functions/predicate";
 import type { ListComprehension } from "./expressions/list/ListComprehension";
@@ -69,7 +70,8 @@ export type Predicate =
     | PredicateFunction
     | Literal<boolean>
     | Case
-    | HasLabel;
+    | HasLabel
+    | IsType;
 
 export type CypherResult = {
     cypher: string;

--- a/src/utils/type-helpers.ts
+++ b/src/utils/type-helpers.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export type ValueOf<T> = T[keyof T];


### PR DESCRIPTION
Add support for [type predicate expressions](https://neo4j.com/docs/cypher-manual/current/values-and-types/type-predicate/) with the functions `Cypher.isType` and `Cypher.isNotType`:

```ts
const variable = new Cypher.Variable();
const unwindClause = new Cypher.Unwind([new Cypher.Literal([42, true, "abc", null]), variable]).return(
    variable,
    Cypher.isType(variable, Cypher.TYPE.INTEGER)
);
```

```cypher
UNWIND [42, true, \\"abc\\", NULL] AS var0
RETURN var0, var0 IS :: INTEGER
```