### PR TITLE
Deprecate innerWith in favor of importWith

### DIFF
--- a/.changeset/eight-socks-work.md
+++ b/.changeset/eight-socks-work.md
@@ -1,0 +1,30 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Prepends WITH on each UNION subquery when `.importWith` is set in parent CALL:
+
+```js
+const returnVar = new Cypher.Variable();
+const n1 = new Cypher.Node({ labels: ["Movie"] });
+const query1 = new Cypher.Match(n1).return([n1, returnVar]);
+const n2 = new Cypher.Node({ labels: ["Movie"] });
+const query2 = new Cypher.Match(n2).return([n2, returnVar]);
+
+const unionQuery = new Cypher.Union(query1, query2);
+const callQuery = new Cypher.Call(unionQuery).importWith(new Cypher.Variable());
+```
+
+The statement `WITH var0` will be added to each UNION subquery
+
+```cypher
+CALL {
+    WITH var0
+    MATCH (this1:Movie)
+    RETURN this1 AS var2
+    UNION
+    WITH var0
+    MATCH (this3:Movie)
+    RETURN this3 AS var2
+}
+```

--- a/.changeset/shy-emus-laugh.md
+++ b/.changeset/shy-emus-laugh.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecate `Call.innerWith` in favor of `Call.importWith`

--- a/src/clauses/Call.test.ts
+++ b/src/clauses/Call.test.ts
@@ -71,14 +71,14 @@ describe("CypherBuilder Call", () => {
         `);
     });
 
-    test("CALL with inner with", () => {
+    test("CALL with import with", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
 
         const matchClause = new Cypher.Match(node)
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
-        const clause = new Cypher.Call(matchClause).innerWith(node);
+        const clause = new Cypher.Call(matchClause).importWith(node);
         const queryResult = clause.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
             "CALL {
@@ -97,12 +97,12 @@ describe("CypherBuilder Call", () => {
         `);
     });
 
-    test("CALL with inner with *", () => {
+    test("CALL with import with *", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
 
         const matchClause = new Cypher.Match(node).return([node.property("title"), "movie"]);
 
-        const clause = new Cypher.Call(matchClause).innerWith("*");
+        const clause = new Cypher.Call(matchClause).importWith("*");
         const queryResult = clause.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
             "CALL {
@@ -114,12 +114,12 @@ describe("CypherBuilder Call", () => {
 
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
-    test("CALL with inner with * and extra fields", () => {
+    test("CALL with import with * and extra fields", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
 
         const matchClause = new Cypher.Match(node).return([node.property("title"), "movie"]);
 
-        const clause = new Cypher.Call(matchClause).innerWith(node, "*");
+        const clause = new Cypher.Call(matchClause).importWith(node, "*");
         const queryResult = clause.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
             "CALL {
@@ -132,14 +132,14 @@ describe("CypherBuilder Call", () => {
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
 
-    test("CALL with inner with without parameters", () => {
+    test("CALL with import with without parameters", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
 
         const matchClause = new Cypher.Match(node)
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
-        const clause = new Cypher.Call(matchClause).innerWith();
+        const clause = new Cypher.Call(matchClause).importWith();
         const queryResult = clause.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
             "CALL {
@@ -157,14 +157,14 @@ describe("CypherBuilder Call", () => {
         `);
     });
 
-    test("CALL with inner with multiple parameters", () => {
+    test("CALL with import with multiple parameters", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
 
         const matchClause = new Cypher.Match(node)
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
-        const clause = new Cypher.Call(matchClause).innerWith(node, new Cypher.Variable());
+        const clause = new Cypher.Call(matchClause).importWith(node, new Cypher.Variable());
         const queryResult = clause.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
             "CALL {
@@ -183,16 +183,16 @@ describe("CypherBuilder Call", () => {
         `);
     });
 
-    test("CALL with inner with fails if inner with is already set", () => {
+    test("CALL with import with fails if import with is already set", () => {
         const node = new Cypher.Node({ labels: ["Movie"] });
 
         const matchClause = new Cypher.Match(node)
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
-        const clause = new Cypher.Call(matchClause).innerWith(node);
+        const clause = new Cypher.Call(matchClause).importWith(node);
         expect(() => {
-            clause.innerWith(node);
+            clause.importWith(node);
         }).toThrow("Call import already set");
     });
 

--- a/src/clauses/Call.ts
+++ b/src/clauses/Call.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import { Union } from "..";
 import type { CypherASTNode } from "../CypherASTNode";
 import type { CypherEnvironment } from "../Environment";
 import type { Variable } from "../references/Variable";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
 import { padBlock } from "../utils/pad-block";
 import { Clause } from "./Clause";
+import { Union } from "./Union";
 import { WithCreate } from "./mixins/clauses/WithCreate";
 import { WithMatch } from "./mixins/clauses/WithMatch";
 import { WithMerge } from "./mixins/clauses/WithMerge";
@@ -34,6 +34,7 @@ import { WithDelete } from "./mixins/sub-clauses/WithDelete";
 import { WithRemove } from "./mixins/sub-clauses/WithRemove";
 import { WithSet } from "./mixins/sub-clauses/WithSet";
 import { ImportWith } from "./sub-clauses/ImportWith";
+import { CompositeClause } from "./utils/concat";
 import { mixin } from "./utils/mixin";
 
 export interface Call
@@ -108,7 +109,7 @@ export class Call extends Clause {
 
     private getSubqueryCypher(env: CypherEnvironment, importWithCypher: string | undefined): string {
         // This ensures the import with is added to all the union subqueries
-        if (this._usingImportWith && this.subquery instanceof Union) {
+        if (this._usingImportWith && (this.subquery instanceof Union || this.subquery instanceof CompositeClause)) {
             //TODO: try to embed the importWithCypher in the environment for a more generic solution
             return this.subquery.getCypher(env, importWithCypher);
         }

--- a/src/clauses/Call.ts
+++ b/src/clauses/Call.ts
@@ -93,15 +93,15 @@ export class Call extends Clause {
 
     /** @internal */
     public getCypher(env: CypherEnvironment): string {
-        const innerWithCypher = compileCypherIfExists(this._importWith, env, { suffix: "\n" });
+        const importWithCypher = compileCypherIfExists(this._importWith, env, { suffix: "\n" });
 
-        const subQueryStr = this.getSubqueryCypher(env, innerWithCypher);
+        const subQueryStr = this.getSubqueryCypher(env, importWithCypher);
 
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
         const deleteCypher = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const setCypher = compileCypherIfExists(this.setSubClause, env, { prefix: "\n" });
 
-        const inCallBlock = `${innerWithCypher}${subQueryStr}`;
+        const inCallBlock = `${importWithCypher}${subQueryStr}`;
         const nextClause = this.compileNextClause(env);
 
         return `CALL {\n${padBlock(inCallBlock)}\n}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;

--- a/src/clauses/Union.test.ts
+++ b/src/clauses/Union.test.ts
@@ -96,8 +96,37 @@ describe("CypherBuilder UNION", () => {
 `);
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
+    test("Union in concat in CALL statement with import with", () => {
+        const returnVar = new Cypher.Variable();
+        const n1 = new Cypher.Node({ labels: ["Movie"] });
+        const query1 = new Cypher.Match(n1).return([n1, returnVar]);
+        const n2 = new Cypher.Node({ labels: ["Movie"] });
+        const query2 = new Cypher.Match(n2).return([n2, returnVar]);
+        const n3 = new Cypher.Node({ labels: ["Movie"] });
+        const query3 = new Cypher.Match(n3).return([n3, returnVar]);
 
-    test("Union in nested CALL statement should append top import with", () => {
+        const unionQuery = new Cypher.Union(query1, query2, query3);
+        const callQuery = new Cypher.Call(Cypher.concat(unionQuery)).importWith(new Cypher.Variable());
+        const queryResult = callQuery.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"CALL {
+    WITH var0
+    MATCH (this1:Movie)
+    RETURN this1 AS var2
+    UNION
+    WITH var0
+    MATCH (this3:Movie)
+    RETURN this3 AS var2
+    UNION
+    WITH var0
+    MATCH (this4:Movie)
+    RETURN this4 AS var2
+}"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("Union in nested CALL statement should not append top import with", () => {
         const returnVar = new Cypher.Variable();
         const n1 = new Cypher.Node({ labels: ["Movie"] });
         const query1 = new Cypher.Match(n1).return([n1, returnVar]);

--- a/src/clauses/Union.test.ts
+++ b/src/clauses/Union.test.ts
@@ -66,4 +66,64 @@ describe("CypherBuilder UNION", () => {
             RETURN this3 AS var1"
         `);
     });
+
+    test("Union in CALL statement with import with", () => {
+        const returnVar = new Cypher.Variable();
+        const n1 = new Cypher.Node({ labels: ["Movie"] });
+        const query1 = new Cypher.Match(n1).return([n1, returnVar]);
+        const n2 = new Cypher.Node({ labels: ["Movie"] });
+        const query2 = new Cypher.Match(n2).return([n2, returnVar]);
+        const n3 = new Cypher.Node({ labels: ["Movie"] });
+        const query3 = new Cypher.Match(n3).return([n3, returnVar]);
+
+        const unionQuery = new Cypher.Union(query1, query2, query3);
+        const callQuery = new Cypher.Call(unionQuery).importWith(new Cypher.Variable());
+        const queryResult = callQuery.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"CALL {
+    WITH var0
+    MATCH (this1:Movie)
+    RETURN this1 AS var2
+    UNION
+    WITH var0
+    MATCH (this3:Movie)
+    RETURN this3 AS var2
+    UNION
+    WITH var0
+    MATCH (this4:Movie)
+    RETURN this4 AS var2
+}"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("Union in nested CALL statement should append top import with", () => {
+        const returnVar = new Cypher.Variable();
+        const n1 = new Cypher.Node({ labels: ["Movie"] });
+        const query1 = new Cypher.Match(n1).return([n1, returnVar]);
+        const n2 = new Cypher.Node({ labels: ["Movie"] });
+        const query2 = new Cypher.Match(n2).return([n2, returnVar]);
+        const n3 = new Cypher.Node({ labels: ["Movie"] });
+        const query3 = new Cypher.Match(n3).return([n3, returnVar]);
+
+        const unionQuery = new Cypher.Union(query1, query2, query3);
+        const callQuery = new Cypher.Call(new Cypher.Call(unionQuery)).importWith(new Cypher.Variable());
+        const queryResult = callQuery.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"CALL {
+    WITH var0
+    CALL {
+        MATCH (this1:Movie)
+        RETURN this1 AS var2
+        UNION
+        MATCH (this3:Movie)
+        RETURN this3 AS var2
+        UNION
+        MATCH (this4:Movie)
+        RETURN this4 AS var2
+    }
+}"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
 });

--- a/src/clauses/Union.ts
+++ b/src/clauses/Union.ts
@@ -40,11 +40,14 @@ export class Union extends Clause {
         return this;
     }
 
-    /** @internal */
-    public getCypher(env: CypherEnvironment): string {
+    /**
+     * If importWithCypher is provided, it will be added at the beginning of each subquery except first
+     *  @internal
+     */
+    public getCypher(env: CypherEnvironment, importWithCypher?: string): string {
         const subqueriesStr = this.subqueries.map((s) => s.getCypher(env));
         const unionStr = this.includeAll ? "UNION ALL" : "UNION";
 
-        return subqueriesStr.join(`\n${unionStr}\n`);
+        return subqueriesStr.join(`\n${unionStr}\n${importWithCypher ?? ""}`);
     }
 }

--- a/src/clauses/utils/concat.ts
+++ b/src/clauses/utils/concat.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { Union } from "../..";
 import type { CypherASTNode } from "../../CypherASTNode";
 import type { CypherEnvironment } from "../../Environment";
 import { filterTruthy } from "../../utils/filter-truthy";
@@ -56,8 +57,14 @@ export class CompositeClause extends Clause {
     }
 
     /** @internal */
-    public getCypher(env: CypherEnvironment): string {
-        const childrenStrs = this._children.map((c) => c.getCypher(env));
+    public getCypher(env: CypherEnvironment, importWithCypher?: string): string {
+        const childrenStrs = this._children.map((c) => {
+            if (importWithCypher && c instanceof Union) {
+                //TODO: try to embed the importWithCypher in the environment for a more generic solution
+                return c.getCypher(env, importWithCypher);
+            }
+            return c.getCypher(env);
+        });
         return childrenStrs.join(this.separator);
     }
 

--- a/src/clauses/utils/concat.ts
+++ b/src/clauses/utils/concat.ts
@@ -58,9 +58,9 @@ export class CompositeClause extends Clause {
 
     /** @internal */
     public getCypher(env: CypherEnvironment, importWithCypher?: string): string {
+        // NOTE: importWithCypher used to pass down import WITH to UNION clauses
         const childrenStrs = this._children.map((c) => {
             if (importWithCypher && c instanceof Union) {
-                //TODO: try to embed the importWithCypher in the environment for a more generic solution
                 return c.getCypher(env, importWithCypher);
             }
             return c.getCypher(env);

--- a/tests/deprecated/call-inner-with.test.ts
+++ b/tests/deprecated/call-inner-with.test.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../../src";
+
+describe("CypherBuilder Call", () => {
+    test("CALL with inner with", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+
+        const matchClause = new Cypher.Match(node)
+            .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
+            .return([node.property("title"), "movie"]);
+
+        const clause = new Cypher.Call(matchClause).innerWith(node);
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "CALL {
+                WITH this0
+                MATCH (this0:Movie)
+                WHERE $param0 = $param1
+                RETURN this0.title AS movie
+            }"
+        `);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": "aa",
+              "param1": "bb",
+            }
+        `);
+    });
+
+    test("CALL with inner with *", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+
+        const matchClause = new Cypher.Match(node).return([node.property("title"), "movie"]);
+
+        const clause = new Cypher.Call(matchClause).innerWith("*");
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "CALL {
+                WITH *
+                MATCH (this0:Movie)
+                RETURN this0.title AS movie
+            }"
+        `);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+    test("CALL with inner with * and extra fields", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+
+        const matchClause = new Cypher.Match(node).return([node.property("title"), "movie"]);
+
+        const clause = new Cypher.Call(matchClause).innerWith(node, "*");
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "CALL {
+                WITH *, this0
+                MATCH (this0:Movie)
+                RETURN this0.title AS movie
+            }"
+        `);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("CALL with inner with without parameters", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+
+        const matchClause = new Cypher.Match(node)
+            .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
+            .return([node.property("title"), "movie"]);
+
+        const clause = new Cypher.Call(matchClause).innerWith();
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "CALL {
+                MATCH (this0:Movie)
+                WHERE $param0 = $param1
+                RETURN this0.title AS movie
+            }"
+        `);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": "aa",
+              "param1": "bb",
+            }
+        `);
+    });
+
+    test("CALL with inner with multiple parameters", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+
+        const matchClause = new Cypher.Match(node)
+            .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
+            .return([node.property("title"), "movie"]);
+
+        const clause = new Cypher.Call(matchClause).innerWith(node, new Cypher.Variable());
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+            "CALL {
+                WITH this0, var1
+                MATCH (this0:Movie)
+                WHERE $param0 = $param1
+                RETURN this0.title AS movie
+            }"
+        `);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": "aa",
+              "param1": "bb",
+            }
+        `);
+    });
+
+    test("CALL with inner with fails if inner with is already set", () => {
+        const node = new Cypher.Node({ labels: ["Movie"] });
+
+        const matchClause = new Cypher.Match(node)
+            .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
+            .return([node.property("title"), "movie"]);
+
+        const clause = new Cypher.Call(matchClause).innerWith(node);
+        expect(() => {
+            clause.innerWith(node);
+        }).toThrow("Call import already set");
+    });
+
+    test("Union in CALL statement with inner with", () => {
+        const returnVar = new Cypher.Variable();
+        const n1 = new Cypher.Node({ labels: ["Movie"] });
+        const query1 = new Cypher.Match(n1).return([n1, returnVar]);
+        const n2 = new Cypher.Node({ labels: ["Movie"] });
+        const query2 = new Cypher.Match(n2).return([n2, returnVar]);
+        const n3 = new Cypher.Node({ labels: ["Movie"] });
+        const query3 = new Cypher.Match(n3).return([n3, returnVar]);
+
+        const unionQuery = new Cypher.Union(query1, query2, query3);
+        const callQuery = new Cypher.Call(unionQuery).innerWith(new Cypher.Variable());
+        const queryResult = callQuery.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"CALL {
+    WITH var0
+    MATCH (this1:Movie)
+    RETURN this1 AS var2
+    UNION
+    MATCH (this3:Movie)
+    RETURN this3 AS var2
+    UNION
+    MATCH (this4:Movie)
+    RETURN this4 AS var2
+}"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+});


### PR DESCRIPTION
Prepends WITH on each UNION subquery when `.importWith` is set in parent CALL:

```js
const returnVar = new Cypher.Variable();
const n1 = new Cypher.Node({ labels: ["Movie"] });
const query1 = new Cypher.Match(n1).return([n1, returnVar]);
const n2 = new Cypher.Node({ labels: ["Movie"] });
const query2 = new Cypher.Match(n2).return([n2, returnVar]);

const unionQuery = new Cypher.Union(query1, query2);
const callQuery = new Cypher.Call(unionQuery).importWith(new Cypher.Variable());
```

The statement `WITH var0` will be added to each UNION subquery

```cypher
CALL {
    WITH var0
    MATCH (this1:Movie)
    RETURN this1 AS var2
    UNION
    WITH var0
    MATCH (this3:Movie)
    RETURN this3 AS var2
}
```