### PR TITLE
Add support for WHERE clauses as pattern predicates

### DIFF
--- a/.changeset/eighty-mangos-add.md
+++ b/.changeset/eighty-mangos-add.md
@@ -1,0 +1,15 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Support for WHERE predicates in patters:
+
+```javascript
+const movie = new Cypher.Node({ labels: ["Movie"] });
+
+new Cypher.Pattern(movie).where(Cypher.eq(movie.property("title"), new Cypher.Literal("The Matrix")));
+```
+
+```cypher
+(this0:Movie WHERE this0.title = "The Matrix")
+```

--- a/docs/modules/ROOT/pages/how-to/type-predicate-expressions.adoc
+++ b/docs/modules/ROOT/pages/how-to/type-predicate-expressions.adoc
@@ -20,7 +20,7 @@ movie.title IS :: STRING
 
 == `isType`
 
-Type predicate expressions can be constructed using `Cypher.isType` (distinct from the `.hasType` method in Relationship). The `isType` function takes a xref:variables-and-params.adoc[Cypher variable] and a type specified in `Cypher.TYPE`:
+Type predicate expressions can be constructed using `Cypher.isType` (distinct from the `.hasType` method in Relationship). The `isType` function takes a xref:variables-and-params/variables.adoc[Cypher variable] and a type specified in `Cypher.TYPE`:
 
 [source, javascript]
 ----

--- a/docs/modules/ROOT/pages/patterns.adoc
+++ b/docs/modules/ROOT/pages/patterns.adoc
@@ -240,10 +240,28 @@ const pattern = new Cypher.Pattern(person).related(actedIn).withLength("*").to(m
 MATCH (this0:Person)-[this1:ACTED_IN*]->(this2:Movie)
 ----
 
+
+=== `WHERE` predicates
+
+`WHERE` clauses can be used as predicates for both nodes and relationships in the pattern:
+
+[source, javascript]
+----
+const movie = new Cypher.Node({ labels: ["Movie"] });
+
+new Cypher.Pattern(movie).where(Cypher.eq(movie.property("title"), new Cypher.Literal("The Matrix")));
+----
+
+[source, cypher]
+----
+(this0:Movie WHERE this0.title = "The Matrix")
+----
+
+
 == Partial patterns
 
 All patterns begin and end with a Node. 
-However, it is possible to define a _partial pattern_ by using `.related` without `.to` afterwards:
+However, it is possible to define a _partial pattern_ by using `.related` without `.to`:
 
 [source, javascript]
 ----

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",
         "neo4j-driver": "^5.9.2",
-        "prettier": "^3.0.3",
+        "prettier": "^3.2.5",
         "ts-jest": "^29.1.1",
         "typedoc": "^0.25.2",
         "typescript": "^5.3.2"

--- a/src/clauses/sub-clauses/Where.ts
+++ b/src/clauses/sub-clauses/Where.ts
@@ -24,7 +24,6 @@ import type { Predicate } from "../../types";
 
 export class Where extends CypherASTNode {
     private wherePredicate: Predicate;
-    protected whereClause = "WHERE";
 
     constructor(parent: CypherASTNode | undefined, whereInput: Predicate) {
         super(parent);

--- a/src/pattern/Pattern.test.ts
+++ b/src/pattern/Pattern.test.ts
@@ -389,4 +389,76 @@ describe("Patterns", () => {
             expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });
     });
+
+    describe("Where predicate", () => {
+        it("Node pattern with where predicate", () => {
+            const node = new Cypher.Node({ labels: ["TestLabel"] });
+
+            const pattern = new Cypher.Pattern(node).where(
+                Cypher.eq(node.property("name"), new Cypher.Literal("Keanu"))
+            );
+            const queryResult = new TestClause(pattern).build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0:TestLabel WHERE this0.name = \\"Keanu\\")"`);
+        });
+
+        it("Node pattern with where predicate and properties", () => {
+            const node = new Cypher.Node({ labels: ["TestLabel"] });
+
+            const pattern = new Cypher.Pattern(node)
+                .where(Cypher.eq(node.property("name"), new Cypher.Literal("Keanu")))
+                .withProperties({
+                    released: new Cypher.Literal(1999),
+                })
+                .related()
+                .to(new Cypher.Node());
+            const queryResult = new TestClause(pattern).build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(
+                `"(this0:TestLabel { released: 1999 } WHERE this0.name = \\"Keanu\\")-[this1]->(this2)"`
+            );
+        });
+
+        it("Node pattern with where predicate in target node", () => {
+            const node = new Cypher.Node({ labels: ["TestLabel"] });
+
+            const pattern = new Cypher.Pattern(node)
+                .related()
+                .to()
+                .where(Cypher.eq(node.property("name"), new Cypher.Literal("Keanu")));
+            const queryResult = new TestClause(pattern).build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(
+                `"(this0:TestLabel)-[this1]->(this2 WHERE this0.name = \\"Keanu\\")"`
+            );
+        });
+
+        it("Relationship pattern with where predicate", () => {
+            const node = new Cypher.Node({ labels: ["TestLabel"] });
+            const relationship = new Cypher.Relationship({ type: "ACTED_IN" });
+
+            const pattern = new Cypher.Pattern(node)
+                .related(relationship)
+                .where(Cypher.eq(relationship.property("role"), new Cypher.Literal("Neo")))
+                .to(new Cypher.Node());
+            const queryResult = new TestClause(pattern).build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(
+                `"(this0:TestLabel)-[this1:ACTED_IN WHERE this1.role = \\"Neo\\"]->(this2)"`
+            );
+        });
+
+        it("Relationship pattern with where predicate and properties", () => {
+            const node = new Cypher.Node({ labels: ["TestLabel"] });
+            const relationship = new Cypher.Relationship({ type: "ACTED_IN" });
+
+            const pattern = new Cypher.Pattern(node)
+                .related(relationship)
+                .where(Cypher.eq(relationship.property("role"), new Cypher.Literal("Neo")))
+                .withProperties({
+                    test: new Cypher.Literal("hello"),
+                })
+                .to(new Cypher.Node());
+            const queryResult = new TestClause(pattern).build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(
+                `"(this0:TestLabel)-[this1:ACTED_IN WHERE this1.role = \\"Neo\\" { test: \\"hello\\" }]->(this2)"`
+            );
+        });
+    });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
         "baseUrl": ".",
         "outDir": "dist",
         "stripInternal": false, // TODO: Change this after validating output .d.ts
-        "noUncheckedIndexedAccess": true,
+        "noUncheckedIndexedAccess": true
     },
-    "include": ["src/**/*", "tests/**/*", "global.d.ts"],
+    "include": ["src/**/*", "tests/**/*", "global.d.ts"]
 }


### PR DESCRIPTION
Support for WHERE predicates in patters:

```javascript
const movie = new Cypher.Node({ labels: ["Movie"] });

new Cypher.Pattern(movie).where(Cypher.eq(movie.property("title"), new Cypher.Literal("The Matrix")));
```

```cypher
(this0:Movie WHERE this0.title = "The Matrix")
```

This is "soft" required for #290 
