### PR TITLE
Add isNormalize and isNotNormalize operators

### DIFF
--- a/.changeset/sharp-moles-compete.md
+++ b/.changeset/sharp-moles-compete.md
@@ -1,0 +1,15 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add `isNormalized` and `isNotNormalized` operators:
+
+```
+const stringLiteral = new Cypher.Literal("the \\u212B char");
+const query = new Cypher.Return([Cypher.isNormalized(stringLiteral, "NFC"), "normalized"]);
+const { cypher } = query.build();
+```
+
+```
+RETURN "the \u212B char" IS NFC NORMALIZED AS normalized
+```

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -78,6 +78,8 @@ export {
     gt,
     gte,
     inOp as in,
+    isNormalized,
+    isNotNormalized,
     isNotNull,
     isNull,
     lt,
@@ -166,7 +168,7 @@ export type { LabelExpr, LabelOperator } from "./expressions/labels/label-expres
 export type { BooleanOp } from "./expressions/operations/boolean";
 export type { ComparisonOp } from "./expressions/operations/comparison";
 export type { Yield } from "./procedures/Yield";
-export type { CypherResult, Expr, Operation, Predicate } from "./types";
+export type { CypherResult, Expr, NormalizationType, Operation, Predicate } from "./types";
 export type { InputArgument } from "./utils/normalize-variable";
 
 // utils

--- a/src/expressions/functions/string.ts
+++ b/src/expressions/functions/string.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import type { Expr } from "../../types";
+import type { Expr, NormalizationType } from "../../types";
 import { filterTruthy } from "../../utils/filter-truthy";
 import { normalizeExpr } from "../../utils/normalize-variable";
 
@@ -48,7 +48,7 @@ export function lTrim(original: Expr): CypherFunction {
  * @param normalForm - A string with the normal form to use or a Cypher expression
  * @example `Cypher.normalize(param, "NFC")`
  */
-export function normalize(input: Expr, normalForm?: "NFC" | "NFD" | "NFKC" | "NFKD" | Expr): CypherFunction {
+export function normalize(input: Expr, normalForm?: NormalizationType | Expr): CypherFunction {
     const normalFormExpr = normalForm ? normalizeExpr(normalForm) : undefined;
     return new CypherFunction("normalize", filterTruthy([input, normalFormExpr]));
 }

--- a/src/expressions/operations/comparison.test.ts
+++ b/src/expressions/operations/comparison.test.ts
@@ -53,4 +53,42 @@ describe("comparison operations", () => {
         const { cypher } = new TestClause(op).build();
         expect(cypher).toMatchInlineSnapshot(`"this0.title IS NOT NULL"`);
     });
+
+    describe("IS NORMALIZED", () => {
+        test("isNormalized (IS NORMALIZED) operator", () => {
+            const stringLiteral = new Cypher.Literal("the \\u212B char");
+            const query = new Cypher.Return([Cypher.isNormalized(stringLiteral), "normalized"]);
+            const { cypher } = query.build();
+            expect(cypher).toMatchInlineSnapshot(`"RETURN \\"the \\\\u212B char\\" IS NORMALIZED AS normalized"`);
+        });
+
+        test.each(["NFC", "NFD", "NFKC", "NFKD"] as const)(
+            "isNormalized (IS NORMALIZED) operator with normalization type %s",
+            (type) => {
+                const stringLiteral = new Cypher.Literal("the \\u212B char");
+                const query = new Cypher.Return([Cypher.isNormalized(stringLiteral, type), "normalized"]);
+                const { cypher } = query.build();
+                expect(cypher).toBe(`RETURN "the \\u212B char" IS ${type} NORMALIZED AS normalized`);
+            }
+        );
+
+        test("isNotNormalized (IS NOT NORMALIZED) operator with one predicate", () => {
+            const stringLiteral = new Cypher.Literal("the \\u212B char");
+            const query = new Cypher.Return([Cypher.isNotNormalized(stringLiteral), "notNormalized"]);
+            const { cypher } = query.build();
+            expect(cypher).toMatchInlineSnapshot(
+                `"RETURN \\"the \\\\u212B char\\" IS NOT NORMALIZED AS notNormalized"`
+            );
+        });
+
+        test.each(["NFC", "NFD", "NFKC", "NFKD"] as const)(
+            "isNotNormalized (IS NOT NORMALIZED) operator with normalization type %s",
+            (type) => {
+                const stringLiteral = new Cypher.Literal("the \\u212B char");
+                const query = new Cypher.Return([Cypher.isNotNormalized(stringLiteral, type), "notNormalized"]);
+                const { cypher } = query.build();
+                expect(cypher).toBe(`RETURN "the \\u212B char" IS NOT ${type} NORMALIZED AS notNormalized`);
+            }
+        );
+    });
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -80,6 +80,8 @@ export type CypherResult = {
     params: Record<string, unknown>;
 };
 
+export type NormalizationType = "NFC" | "NFD" | "NFKC" | "NFKD";
+
 /** Defines the interface for a class that can be compiled into Cypher */
 export interface CypherCompilable {
     getCypher(env: CypherEnvironment): string;


### PR DESCRIPTION
Add `isNormalized` and `isNotNormalized` operators (https://neo4j.com/docs/cypher-manual/current/syntax/operators/#match-string-is-normalized)

```
const stringLiteral = new Cypher.Literal("the \\u212B char");
const query = new Cypher.Return([Cypher.isNormalized(stringLiteral, "NFC"), "normalized"]);
const { cypher } = query.build();
```

```
RETURN "the \u212B char" IS NFC NORMALIZED AS normalized
```