### PR TITLE
291 change cdc procedures namespace

### DIFF
--- a/.changeset/old-apples-type.md
+++ b/.changeset/old-apples-type.md
@@ -1,0 +1,11 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecate `Cypher.cdc` Procedures in favor of `Cypher.db.cdc`:
+
+-   `Cypher.cdc.current` in favor of `Cypher.db.cdc.current`
+-   `Cypher.cdc.earliest` in favor of `Cypher.db.cdc.earliest`
+-   `Cypher.cdc.query` in favor of `Cypher.db.cdc.query`
+
+This new procedures also update the generated Cypher namespace to `db.cdc`

--- a/docs/modules/ROOT/pages/how-to/use-change-data-capture.adoc
+++ b/docs/modules/ROOT/pages/how-to/use-change-data-capture.adoc
@@ -4,10 +4,14 @@
 
 link:https://neo4j.com/docs/cdc/current/[Change Data Capture] (CDC) queries can be created with the Cypher Builder by using the Procedures in the `cdc` namespace:
 
-* `Cypher.cdc.current()`
-* `Cypher.cdc.earliest()`
-* `Cypher.cdc.query(from, selectors)`
+* `Cypher.db.cdc.current()`
+* `Cypher.db.cdc.earliest()`
+* `Cypher.db.cdc.query(from, selectors)`
 
+[WARNING]
+====
+Previous to Neo4j version 5.17, the namespace for cdc procedures is `cdc.x` instead of `db.cdc.x`, this namespace is available in Cypher Builder through the deprecated functions `Cypher.cdc.x`
+====
 
 == Examples
 
@@ -17,14 +21,14 @@ In order to query changes, you need to acquire a change identifier. This can be 
 
 [source, javascript]
 ----
-const query = Cypher.cdc.current().yield("id");
+const query = Cypher.db.cdc.current().yield("id");
 const { cypher } = query.build();
 ----
 
 
 [source, cypher]
 ----
-CALL cdc.current() YIELD id
+CALL db.cdc.current() YIELD id
 ----
 
 
@@ -34,13 +38,13 @@ To query changes in the graph, follow these instructions:
 
 [source, javascript]
 ----
-const query = Cypher.cdc.query(fromId);
+const query = Cypher.db.cdc.query(fromId);
 const { cypher } = query.build();
 ----
 
 [source, cypher]
 ----
-CALL cdc.query("cdc-id", [])
+CALL db.cdc.query("cdc-id", [])
 ----
 
 
@@ -58,13 +62,13 @@ const selector = new Cypher.Map({
 });
 
 
-const query = Cypher.cdc.query(fromId, [selector]);
+const query = Cypher.db.cdc.query(fromId, [selector]);
 const { cypher } = query.build();
 ----
 
 [source, cypher]
 ----
-CALL cdc.query("cdc-id", [{
+CALL db.cdc.query("cdc-id", [{
     select: "e",
     operation: "c",
     changesTo: ["name", "title"]

--- a/src/namespaces/db/cdc.test.ts
+++ b/src/namespaces/db/cdc.test.ts
@@ -21,30 +21,30 @@ import Cypher from "../../index";
 
 describe("CDC procedures", () => {
     test("cdc.current", () => {
-        const query = Cypher.cdc.current();
+        const query = Cypher.db.cdc.current();
         const { cypher } = query.build();
 
-        expect(cypher).toMatchInlineSnapshot(`"CALL cdc.current()"`);
+        expect(cypher).toMatchInlineSnapshot(`"CALL db.cdc.current()"`);
     });
 
     test("cdc.current with yield", () => {
-        const query = Cypher.cdc.current().yield("id");
+        const query = Cypher.db.cdc.current().yield("id");
         const { cypher } = query.build();
 
-        expect(cypher).toMatchInlineSnapshot(`"CALL cdc.current() YIELD id"`);
+        expect(cypher).toMatchInlineSnapshot(`"CALL db.cdc.current() YIELD id"`);
     });
     test("cdc.earliest", () => {
-        const query = Cypher.cdc.earliest();
+        const query = Cypher.db.cdc.earliest();
         const { cypher } = query.build();
 
-        expect(cypher).toMatchInlineSnapshot(`"CALL cdc.earliest()"`);
+        expect(cypher).toMatchInlineSnapshot(`"CALL db.cdc.earliest()"`);
     });
 
     test("cdc.earliest with yield", () => {
-        const query = Cypher.cdc.earliest().yield("id");
+        const query = Cypher.db.cdc.earliest().yield("id");
         const { cypher } = query.build();
 
-        expect(cypher).toMatchInlineSnapshot(`"CALL cdc.earliest() YIELD id"`);
+        expect(cypher).toMatchInlineSnapshot(`"CALL db.cdc.earliest() YIELD id"`);
     });
 
     describe("cdc.query", () => {
@@ -55,26 +55,26 @@ describe("CDC procedures", () => {
         });
 
         test("with string", () => {
-            const query = Cypher.cdc.query("my-cursor");
+            const query = Cypher.db.cdc.query("my-cursor");
             const { cypher } = query.build();
 
-            expect(cypher).toMatchInlineSnapshot(`"CALL cdc.query(\\"my-cursor\\", [])"`);
+            expect(cypher).toMatchInlineSnapshot(`"CALL db.cdc.query(\\"my-cursor\\", [])"`);
         });
 
         test("with literal", () => {
-            const query = Cypher.cdc.query(new Cypher.Literal("my-cursor"));
+            const query = Cypher.db.cdc.query(new Cypher.Literal("my-cursor"));
             const { cypher } = query.build();
 
-            expect(cypher).toMatchInlineSnapshot(`"CALL cdc.query(\\"my-cursor\\", [])"`);
+            expect(cypher).toMatchInlineSnapshot(`"CALL db.cdc.query(\\"my-cursor\\", [])"`);
         });
 
         test("with selectors in array", () => {
-            const query = Cypher.cdc.query("my-cursor", [selector]);
+            const query = Cypher.db.cdc.query("my-cursor", [selector]);
 
             const { cypher } = query.build();
 
             expect(cypher).toMatchInlineSnapshot(
-                `"CALL cdc.query(\\"my-cursor\\", [{ select: \\"e\\", operation: \\"c\\", changesTo: [\\"name\\", \\"title\\"] }])"`
+                `"CALL db.cdc.query(\\"my-cursor\\", [{ select: \\"e\\", operation: \\"c\\", changesTo: [\\"name\\", \\"title\\"] }])"`
             );
         });
     });

--- a/src/namespaces/db/cdc.ts
+++ b/src/namespaces/db/cdc.ts
@@ -24,25 +24,22 @@ import { normalizeExpr, normalizeList } from "../../utils/normalize-variable";
 /** Acquire a change identifier for the last committed transaction
  * @see [Neo4j Documentation](https://neo4j.com/docs/cdc/current/procedures/current/)
  * @group Procedures
- * @deprecated Use {@link db.cdc.current} instead
  */
 export function current(): CypherProcedure<"id"> {
-    return new CypherProcedure("cdc.current");
+    return new CypherProcedure("db.cdc.current");
 }
 
 /** Acquire a change identifier for the earliest available change
  * @see [Neo4j Documentation](https://neo4j.com/docs/cdc/current/procedures/earliest/)
  * @group Procedures
- * @deprecated Use {@link db.cdc.earliest} instead
  */
 export function earliest(): CypherProcedure<"id"> {
-    return new CypherProcedure("cdc.earliest");
+    return new CypherProcedure("db.cdc.earliest");
 }
 
 /** Query the database for captured changes
  * @see [Neo4j Documentation](https://neo4j.com/docs/cdc/current/procedures/query/)
  * @group Procedures
- * @deprecated Use {@link db.cdc.query} instead
  */
 export function query(
     from: string | Expr,
@@ -50,5 +47,5 @@ export function query(
 ): CypherProcedure<"id" | "txId" | "seq" | "metadata" | "event"> {
     const fromExpr = normalizeExpr(from);
     const selectorsExpr = normalizeList(selectors);
-    return new CypherProcedure("cdc.query", [fromExpr, selectorsExpr]);
+    return new CypherProcedure("db.cdc.query", [fromExpr, selectorsExpr]);
 }

--- a/src/namespaces/db/db.ts
+++ b/src/namespaces/db/db.ts
@@ -22,6 +22,7 @@ import { CypherProcedure } from "../../procedures/CypherProcedure";
 import type { Expr } from "../../types";
 import { normalizeExpr } from "../../utils/normalize-variable";
 
+export * as cdc from "./cdc";
 export * as index from "./dbIndex";
 
 /** Returns all labels in the database

--- a/tests/deprecated/cdc.test.ts
+++ b/tests/deprecated/cdc.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../../src/index";
+
+describe("CDC procedures", () => {
+    test("cdc.current", () => {
+        const query = Cypher.cdc.current();
+        const { cypher } = query.build();
+
+        expect(cypher).toMatchInlineSnapshot(`"CALL cdc.current()"`);
+    });
+
+    test("cdc.current with yield", () => {
+        const query = Cypher.cdc.current().yield("id");
+        const { cypher } = query.build();
+
+        expect(cypher).toMatchInlineSnapshot(`"CALL cdc.current() YIELD id"`);
+    });
+    test("cdc.earliest", () => {
+        const query = Cypher.cdc.earliest();
+        const { cypher } = query.build();
+
+        expect(cypher).toMatchInlineSnapshot(`"CALL cdc.earliest()"`);
+    });
+
+    test("cdc.earliest with yield", () => {
+        const query = Cypher.cdc.earliest().yield("id");
+        const { cypher } = query.build();
+
+        expect(cypher).toMatchInlineSnapshot(`"CALL cdc.earliest() YIELD id"`);
+    });
+
+    describe("cdc.query", () => {
+        const selector = new Cypher.Map({
+            select: new Cypher.Literal("e"),
+            operation: new Cypher.Literal("c"),
+            changesTo: new Cypher.List([new Cypher.Literal("name"), new Cypher.Literal("title")]),
+        });
+
+        test("with string", () => {
+            const query = Cypher.cdc.query("my-cursor");
+            const { cypher } = query.build();
+
+            expect(cypher).toMatchInlineSnapshot(`"CALL cdc.query(\\"my-cursor\\", [])"`);
+        });
+
+        test("with literal", () => {
+            const query = Cypher.cdc.query(new Cypher.Literal("my-cursor"));
+            const { cypher } = query.build();
+
+            expect(cypher).toMatchInlineSnapshot(`"CALL cdc.query(\\"my-cursor\\", [])"`);
+        });
+
+        test("with selectors in array", () => {
+            const query = Cypher.cdc.query("my-cursor", [selector]);
+
+            const { cypher } = query.build();
+
+            expect(cypher).toMatchInlineSnapshot(
+                `"CALL cdc.query(\\"my-cursor\\", [{ select: \\"e\\", operation: \\"c\\", changesTo: [\\"name\\", \\"title\\"] }])"`
+            );
+        });
+    });
+});


### PR DESCRIPTION
Deprecate `Cypher.cdc` Procedures in favor of `Cypher.db.cdc`:

-   `Cypher.cdc.current` in favor of `Cypher.db.cdc.current`
-   `Cypher.cdc.earliest` in favor of `Cypher.db.cdc.earliest`
-   `Cypher.cdc.query` in favor of `Cypher.db.cdc.query`

This new procedures also update the generated Cypher namespace to `db.cdc`

The old procedures are still available an will be deprecated in Cypher Builder 2.0