### PR TITLE
Move index procedures to an index folder

### DIFF
--- a/src/namespaces/db/db.ts
+++ b/src/namespaces/db/db.ts
@@ -23,7 +23,7 @@ import type { Expr } from "../../types";
 import { normalizeExpr } from "../../utils/normalize-variable";
 
 export * as cdc from "./cdc";
-export * as index from "./dbIndex";
+export * as index from "./index/dbIndex";
 
 /** Returns all labels in the database
  * @see [Neo4j Documentation](https://neo4j.com/docs/operations-manual/5/reference/procedures/#procedure_db_labels)

--- a/src/namespaces/db/index/dbIndex.ts
+++ b/src/namespaces/db/index/dbIndex.ts
@@ -17,5 +17,5 @@
  * limitations under the License.
  */
 
-export * as fulltext from "./fulltext";
-export * as vector from "./vector";
+export * as fulltext from "../index/fulltext";
+export * as vector from "../index/vector";

--- a/src/namespaces/db/index/fulltext.ts
+++ b/src/namespaces/db/index/fulltext.ts
@@ -17,11 +17,11 @@
  * limitations under the License.
  */
 
-import type { Literal, Param, Variable } from "../../Cypher";
-import { CypherProcedure } from "../../procedures/CypherProcedure";
-import type { Expr } from "../../types";
-import type { InputArgument } from "../../utils/normalize-variable";
-import { normalizeVariable, normalizeMap } from "../../utils/normalize-variable";
+import type { Literal, Param, Variable } from "../../../Cypher";
+import { CypherProcedure } from "../../../procedures/CypherProcedure";
+import type { Expr } from "../../../types";
+import type { InputArgument } from "../../../utils/normalize-variable";
+import { normalizeMap, normalizeVariable } from "../../../utils/normalize-variable";
 
 type FulltextPhrase = string | Literal<string> | Param | Variable;
 

--- a/src/namespaces/db/index/vector.ts
+++ b/src/namespaces/db/index/vector.ts
@@ -17,10 +17,10 @@
  * limitations under the License.
  */
 
-import type { Literal } from "../../Cypher";
-import { CypherProcedure } from "../../procedures/CypherProcedure";
-import type { Expr } from "../../types";
-import { normalizeVariable } from "../../utils/normalize-variable";
+import type { Literal } from "../../../Cypher";
+import { CypherProcedure } from "../../../procedures/CypherProcedure";
+import type { Expr } from "../../../types";
+import { normalizeVariable } from "../../../utils/normalize-variable";
 
 /** Returns all labels in the database
  * @see [Neo4j Documentation](https://neo4j.com/docs/operations-manual/current/reference/procedures/#procedure_db_index_vector_queryNodes)


### PR DESCRIPTION
To better match the namespace organization. Move index namespace inside a folder in db

All functionality remains the same