### PR TITLE
Escape double quotes in string literal values

### DIFF
--- a/src/references/Literal.ts
+++ b/src/references/Literal.ts
@@ -38,7 +38,8 @@ export class Literal<T extends LiteralValue = LiteralValue> implements CypherCom
 
     private formatLiteralValue(value: LiteralValue): string {
         if (typeof value === "string") {
-            return `"${value}"`;
+            const escaped = this.escapeStringValue(value)
+            return `"${escaped}"`;
         }
         if (value === null) {
             return "NULL";
@@ -48,6 +49,10 @@ export class Literal<T extends LiteralValue = LiteralValue> implements CypherCom
             return `[${serializedValues.join(", ")}]`;
         }
         return `${value}`;
+    }
+
+    private escapeStringValue(value: string) {
+        return value.replace(/"/g, '\\"');
     }
 }
 


### PR DESCRIPTION
String literal values are not being escaped during the `getCypher()` for literal values. 

Before:
```cypher
MATCH(n)
WHERE n.foo = ""bar""
RETURN n limit 1
```

After:
```cypher
MATCH(n)
WHERE n.foo = "\"bar\""
RETURN n limit 1
```
