### PR TITLE
Add callProcedure method to With and Match clauses

### DIFF
--- a/.changeset/afraid-ears-chew.md
+++ b/.changeset/afraid-ears-chew.md
@@ -1,0 +1,9 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Add callProcedure method to With and Match clauses
+
+```js
+const withQuery = new Cypher.With("*").callProcedure(Cypher.db.labels()).yield("label");
+```

--- a/docs/modules/ROOT/pages/procedures.adoc
+++ b/docs/modules/ROOT/pages/procedures.adoc
@@ -21,6 +21,14 @@ const { cypher, params } = dbLabels.build();
 
 Cypher Builder has several built-in procedures such as `db.*` procedures that can be called as JavaScript functions. 
 
+You can add procedures following other clauses using the `callProcedure` method:
+
+[source, javascript]
+----
+const withQuery = new Cypher.With("*").callProcedure(Cypher.db.labels()).yield("label");
+const { cypher, params } = withQuery.build();
+----
+
 == Custom Procedures
 
 Most procedures depend on the Neo4j setup, and such need to be defined with the `Procedure` class:

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -681,4 +681,34 @@ WHERE this0.title = $param1"
 `);
         });
     });
+
+    describe("Match.callProcedure", () => {
+        test("Match.match()", () => {
+            const movie1 = new Cypher.Node({
+                labels: ["Movie"],
+            });
+
+            const labels = new Cypher.Variable();
+
+            const matchQuery = new Cypher.Match(movie1)
+                .where(Cypher.eq(movie1.property("title"), new Cypher.Param("movie1")))
+                .callProcedure(new Cypher.Procedure("db.labels"))
+                .yield(["label", labels])
+                .return(labels);
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+WHERE this0.title = $param0
+CALL db.labels() YIELD label AS var1
+RETURN var1"
+`);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`
+{
+  "param0": "movie1",
+}
+`);
+        });
+    });
 });

--- a/src/clauses/Match.ts
+++ b/src/clauses/Match.ts
@@ -23,6 +23,7 @@ import type { NodeRef } from "../references/NodeRef";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
 import { Clause } from "./Clause";
 import { WithPathAssign } from "./mixins/WithPathAssign";
+import { WithCallProcedure } from "./mixins/clauses/WithCallProcedure";
 import { WithCreate } from "./mixins/clauses/WithCreate";
 import { WithFinish } from "./mixins/clauses/WithFinish";
 import { WithMerge } from "./mixins/clauses/WithMerge";
@@ -46,7 +47,8 @@ export interface Match
         WithUnwind,
         WithCreate,
         WithMerge,
-        WithFinish {}
+        WithFinish,
+        WithCallProcedure {}
 
 /**
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/match/)
@@ -63,7 +65,8 @@ export interface Match
     WithUnwind,
     WithCreate,
     WithMerge,
-    WithFinish
+    WithFinish,
+    WithCallProcedure
 )
 export class Match extends Clause {
     private pattern: Pattern;

--- a/src/clauses/With.test.ts
+++ b/src/clauses/With.test.ts
@@ -276,4 +276,28 @@ MERGE (this0:Movie)"
             expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });
     });
+
+    describe("Chained Procedure", () => {
+        test("With * and cypher procedure", () => {
+            const withQuery = new Cypher.With("*").callProcedure(Cypher.db.labels()).yield("label");
+
+            const queryResult = withQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"WITH *
+CALL db.labels() YIELD label"
+`);
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("With * and cypher void procedure", () => {
+            const withQuery = new Cypher.With("*").callProcedure(Cypher.apoc.util.validate(Cypher.true, "message"));
+
+            const queryResult = withQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"WITH *
+CALL apoc.util.validate(true, \\"message\\", [0])"
+`);
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+    });
 });

--- a/src/clauses/mixins/clauses/WithCallProcedure.ts
+++ b/src/clauses/mixins/clauses/WithCallProcedure.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { CypherProcedure, VoidCypherProcedure } from "../../../procedures/CypherProcedure";
+import { MixinClause } from "../Mixin";
+
+export abstract class WithCallProcedure extends MixinClause {
+    /** Add a call {@link Procedure} clause
+     * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/call/)
+     */
+    public callProcedure<T extends CypherProcedure | VoidCypherProcedure>(procedure: T): T {
+        this.addNextClause(procedure);
+        return procedure;
+    }
+}


### PR DESCRIPTION
Add callProcedure method to With and Match clauses

```js
const withQuery = new Cypher.With("*").callProcedure(Cypher.db.labels()).yield("label");
```