### PR TITLE
Use constants for namespace strings

### DIFF
--- a/src/expressions/functions/CypherFunctions.ts
+++ b/src/expressions/functions/CypherFunctions.ts
@@ -37,9 +37,9 @@ export class CypherFunction extends CypherASTNode {
     protected name: string;
     private params: Array<Expr> = [];
 
-    constructor(name: string, params: Array<Expr> = []) {
+    constructor(name: string, params: Array<Expr> = [], namespace?: string) {
         super();
-        this.name = name;
+        this.name = namespace ? `${namespace}.${name}` : name;
         for (const param of params) {
             this.addParam(param);
         }

--- a/src/namespaces/db/cdc.ts
+++ b/src/namespaces/db/cdc.ts
@@ -21,12 +21,14 @@ import type { Expr } from "../..";
 import { CypherProcedure } from "../../procedures/CypherProcedure";
 import { normalizeExpr, normalizeList } from "../../utils/normalize-variable";
 
+const CDC_NAMESPACE = "db.cdc";
+
 /** Acquire a change identifier for the last committed transaction
  * @see [Neo4j Documentation](https://neo4j.com/docs/cdc/current/procedures/current/)
  * @group Procedures
  */
 export function current(): CypherProcedure<"id"> {
-    return new CypherProcedure("db.cdc.current");
+    return new CypherProcedure("current", [], CDC_NAMESPACE);
 }
 
 /** Acquire a change identifier for the earliest available change
@@ -34,7 +36,7 @@ export function current(): CypherProcedure<"id"> {
  * @group Procedures
  */
 export function earliest(): CypherProcedure<"id"> {
-    return new CypherProcedure("db.cdc.earliest");
+    return new CypherProcedure("earliest", [], CDC_NAMESPACE);
 }
 
 /** Query the database for captured changes
@@ -47,5 +49,5 @@ export function query(
 ): CypherProcedure<"id" | "txId" | "seq" | "metadata" | "event"> {
     const fromExpr = normalizeExpr(from);
     const selectorsExpr = normalizeList(selectors);
-    return new CypherProcedure("db.cdc.query", [fromExpr, selectorsExpr]);
+    return new CypherProcedure("query", [fromExpr, selectorsExpr], CDC_NAMESPACE);
 }

--- a/src/namespaces/db/db.ts
+++ b/src/namespaces/db/db.ts
@@ -27,12 +27,14 @@ export * as cdc from "./cdc";
 export * as index from "./index/dbIndex";
 export * as schema from "./schema";
 
+const DB_NAMESPACE = "db";
+
 /** Returns all labels in the database
  * @see [Neo4j Documentation](https://neo4j.com/docs/operations-manual/5/reference/procedures/#procedure_db_labels)
  * @group Procedures
  */
 export function labels(): CypherProcedure<"label"> {
-    return new CypherProcedure("db.labels");
+    return new CypherProcedure("labels", [], DB_NAMESPACE);
 }
 
 /**
@@ -41,7 +43,7 @@ export function labels(): CypherProcedure<"label"> {
  */
 export function nameFromElementId(dbName: Expr | string): CypherFunction {
     const dbNameExpr = normalizeExpr(dbName);
-    return new CypherFunction("db.nameFromElementId", [dbNameExpr]);
+    return new CypherFunction("nameFromElementId", [dbNameExpr], DB_NAMESPACE);
 }
 
 /**
@@ -49,7 +51,7 @@ export function nameFromElementId(dbName: Expr | string): CypherFunction {
  * @group Procedures
  */
 export function info(): CypherProcedure<"id" | "creationDate"> {
-    return new CypherProcedure("db.info");
+    return new CypherProcedure("info", [], DB_NAMESPACE);
 }
 
 /**
@@ -58,7 +60,7 @@ export function info(): CypherProcedure<"id" | "creationDate"> {
  */
 export function createLabel(newLabel: Expr | string): VoidCypherProcedure {
     const newLabelExpr = normalizeExpr(newLabel);
-    return new CypherProcedure("db.createLabel", [newLabelExpr]);
+    return new CypherProcedure("createLabel", [newLabelExpr], DB_NAMESPACE);
 }
 
 /**
@@ -67,7 +69,7 @@ export function createLabel(newLabel: Expr | string): VoidCypherProcedure {
  */
 export function createProperty(newProperty: Expr | string): VoidCypherProcedure {
     const newPropertyExpr = normalizeExpr(newProperty);
-    return new CypherProcedure("db.createProperty", [newPropertyExpr]);
+    return new CypherProcedure("createProperty", [newPropertyExpr], DB_NAMESPACE);
 }
 
 /**
@@ -76,5 +78,5 @@ export function createProperty(newProperty: Expr | string): VoidCypherProcedure 
  */
 export function createRelationshipType(newRelationshipType: Expr | string): VoidCypherProcedure {
     const newRelationshipTypeExpr = normalizeExpr(newRelationshipType);
-    return new CypherProcedure("db.createRelationshipType", [newRelationshipTypeExpr]);
+    return new CypherProcedure("createRelationshipType", [newRelationshipTypeExpr], DB_NAMESPACE);
 }

--- a/src/namespaces/db/index/fulltext.ts
+++ b/src/namespaces/db/index/fulltext.ts
@@ -25,6 +25,8 @@ import { normalizeMap, normalizeVariable } from "../../../utils/normalize-variab
 
 type FulltextPhrase = string | Literal<string> | Param | Variable;
 
+const FULLTEXT_NAMESPACE = "db.index.fulltext";
+
 /** Returns all labels in the database
  * @see [Neo4j Documentation](https://neo4j.com/docs/operations-manual/current/reference/procedures/#procedure_db_index_fulltext_querynodes)
  * @group Procedures
@@ -36,7 +38,7 @@ export function queryNodes(
 ): CypherProcedure<"node" | "score"> {
     const procedureArgs = getFulltextArguments(indexName, queryString, options);
 
-    return new CypherProcedure("db.index.fulltext.queryNodes", procedureArgs);
+    return new CypherProcedure("queryNodes", procedureArgs, FULLTEXT_NAMESPACE);
 }
 
 /** Returns all labels in the database
@@ -50,7 +52,7 @@ export function queryRelationships(
 ): CypherProcedure<"relationship" | "score"> {
     const procedureArgs = getFulltextArguments(indexName, queryString, options);
 
-    return new CypherProcedure("db.index.fulltext.queryRelationships", procedureArgs);
+    return new CypherProcedure("queryRelationships", procedureArgs, FULLTEXT_NAMESPACE);
 }
 
 function getFulltextArguments(

--- a/src/namespaces/db/index/vector.ts
+++ b/src/namespaces/db/index/vector.ts
@@ -22,6 +22,8 @@ import { CypherProcedure } from "../../../procedures/CypherProcedure";
 import type { Expr } from "../../../types";
 import { normalizeVariable } from "../../../utils/normalize-variable";
 
+const VECTOR_NAMESPACE = "db.index.vector";
+
 /** Returns all labels in the database
  * @see [Neo4j Documentation](https://neo4j.com/docs/operations-manual/current/reference/procedures/#procedure_db_index_vector_queryNodes)
  * @group Procedures
@@ -33,7 +35,7 @@ export function queryNodes(
 ): CypherProcedure<"node" | "score"> {
     const procedureArgs = getVectorArguments(indexName, numberOfNearestNeighbours, query);
 
-    return new CypherProcedure("db.index.vector.queryNodes", procedureArgs);
+    return new CypherProcedure("queryNodes", procedureArgs, VECTOR_NAMESPACE);
 }
 
 /** Returns all labels in the database
@@ -47,7 +49,7 @@ export function queryRelationships(
 ): CypherProcedure<"relationship" | "score"> {
     const procedureArgs = getVectorArguments(indexName, numberOfNearestNeighbours, query);
 
-    return new CypherProcedure("db.index.vector.queryRelationships", procedureArgs);
+    return new CypherProcedure("queryRelationships", procedureArgs, VECTOR_NAMESPACE);
 }
 
 function getVectorArguments(

--- a/src/namespaces/db/schema.ts
+++ b/src/namespaces/db/schema.ts
@@ -19,6 +19,8 @@
 
 import { CypherProcedure } from "../../procedures/CypherProcedure";
 
+const SCHEMA_NAMESPACE = "db.schema";
+
 /**
  * @see [Neo4j Documentation](https://neo4j.com/docs/operations-manual/current/reference/procedures/#procedure_db_schema_nodetypeproperties)
  * @group Procedures
@@ -26,7 +28,7 @@ import { CypherProcedure } from "../../procedures/CypherProcedure";
 export function nodeTypeProperties(): CypherProcedure<
     "nodeType" | "nodeLabels" | "propertyName" | "propertyTypes" | "mandatory"
 > {
-    return new CypherProcedure("db.schema.nodeTypeProperties");
+    return new CypherProcedure("nodeTypeProperties", [], SCHEMA_NAMESPACE);
 }
 
 /**
@@ -34,12 +36,12 @@ export function nodeTypeProperties(): CypherProcedure<
  * @group Procedures
  */
 export function relTypeProperties(): CypherProcedure<"relType" | "propertyName" | "propertyTypes" | "mandatory"> {
-    return new CypherProcedure("db.schema.relTypeProperties");
+    return new CypherProcedure("relTypeProperties", [], SCHEMA_NAMESPACE);
 }
 /**
  * @see [Neo4j Documentation](https://neo4j.com/docs/operations-manual/current/reference/procedures/#procedure_db_schema_visualization)
  * @group Procedures
  */
 export function visualization(): CypherProcedure<"nodes" | "relationships"> {
-    return new CypherProcedure("db.schema.visualization");
+    return new CypherProcedure("visualization", [], SCHEMA_NAMESPACE);
 }

--- a/src/namespaces/genai/vector.ts
+++ b/src/namespaces/genai/vector.ts
@@ -23,6 +23,8 @@ import { CypherProcedure } from "../../procedures/CypherProcedure";
 import type { Expr } from "../../types";
 import { normalizeMap, normalizeVariable } from "../../utils/normalize-variable";
 
+const GENAI_VECTOR_NAMESPACE = "genai.vector";
+
 /** Encode a given resource as a vector using the named provider.
  * @see [Neo4j Documentation](https://neo4j.com/docs/cypher-manual/current/functions/#header-query-functions-genai)
  * @group Functions
@@ -32,11 +34,11 @@ export function encode(
     provider: string | Literal<string> | Param,
     configuration: Record<string, string | number | Literal | Param>
 ): CypherFunction {
-    return new CypherFunction("genai.vector.encode", [
-        resource,
-        normalizeVariable(provider),
-        normalizeMap(configuration),
-    ]);
+    return new CypherFunction(
+        "encode",
+        [resource, normalizeVariable(provider), normalizeMap(configuration)],
+        GENAI_VECTOR_NAMESPACE
+    );
 }
 
 /** Encode a given batch of resources as vectors using the named provider.
@@ -48,9 +50,9 @@ export function encodeBatch(
     provider: string | Literal<string> | Param,
     configuration: Record<string, string | number | Literal | Param>
 ): CypherProcedure<"index" | "resource" | "vector"> {
-    return new CypherProcedure("genai.vector.encodeBatch", [
-        resources,
-        normalizeVariable(provider),
-        normalizeMap(configuration),
-    ]);
+    return new CypherProcedure(
+        "encodeBatch",
+        [resources, normalizeVariable(provider), normalizeMap(configuration)],
+        GENAI_VECTOR_NAMESPACE
+    );
 }

--- a/src/namespaces/tx.ts
+++ b/src/namespaces/tx.ts
@@ -23,12 +23,14 @@ import type { Literal } from "../references/Literal";
 import type { Param } from "../references/Param";
 import { normalizeMap } from "../utils/normalize-variable";
 
+const TX_NAMESPACE = "tx";
+
 /**
  * @see [Neo4j Documentation](https://neo4j.com/docs/operations-manual/current/reference/procedures/#procedure_tx_getmetadata)
  * @group Procedures
  */
 export function getMetaData(): CypherProcedure<"metadata"> {
-    return new CypherProcedure("tx.getMetaData");
+    return new CypherProcedure("getMetaData", [], TX_NAMESPACE);
 }
 
 /**
@@ -36,5 +38,5 @@ export function getMetaData(): CypherProcedure<"metadata"> {
  * @group Procedures
  */
 export function setMetaData(data: Record<string, string | number | Literal | Param>): VoidCypherProcedure {
-    return new CypherProcedure("tx.setMetaData", [normalizeMap(data)]);
+    return new CypherProcedure("setMetaData", [normalizeMap(data)], TX_NAMESPACE);
 }

--- a/src/namespaces/vector/similarity.ts
+++ b/src/namespaces/vector/similarity.ts
@@ -20,12 +20,14 @@
 import { CypherFunction } from "../../expressions/functions/CypherFunctions";
 import type { Expr } from "../../types";
 
+const VECTOR_SIMILARITY_NAMESPACE = "vector.similarity";
+
 /** Returns a FLOAT representing the similarity between the argument vectors based on their Euclidean distance.
  * @see [Neo4j Documentation](https://neo4j.com/docs/cypher-manual/current/functions/vector/#functions-similarity-euclidean)
  * @group Procedures
  */
 export function euclidean(a: Expr, b: Expr): CypherFunction {
-    return new CypherFunction("vector.similarity.euclidean", [a, b]);
+    return new CypherFunction("euclidean", [a, b], VECTOR_SIMILARITY_NAMESPACE);
 }
 
 /** Returns a FLOAT representing the similarity between the argument vectors based on their cosine.
@@ -33,5 +35,5 @@ export function euclidean(a: Expr, b: Expr): CypherFunction {
  * @group Procedures
  */
 export function cosine(a: Expr, b: Expr): CypherFunction {
-    return new CypherFunction("vector.similarity.cosine", [a, b]);
+    return new CypherFunction("cosine", [a, b], VECTOR_SIMILARITY_NAMESPACE);
 }

--- a/src/procedures/CypherProcedure.ts
+++ b/src/procedures/CypherProcedure.ts
@@ -33,9 +33,9 @@ export class VoidCypherProcedure extends Clause {
     protected name: string;
     private params: Array<Expr>;
 
-    constructor(name: string, params: Array<Expr> = []) {
+    constructor(name: string, params: Array<Expr> = [], namespace?: string) {
         super();
-        this.name = name;
+        this.name = namespace ? `${namespace}.${name}` : name;
         this.params = params;
         for (const param of params) {
             if (param instanceof CypherASTNode) {


### PR DESCRIPTION
Adds the parameter namespace to functions and procedures, so a constant can be use to reduce duplicity of namespace strings between functions 