### PR TITLE
Update call, create and foreach tests to not use deprecated syntax

### DIFF
--- a/src/clauses/Call.test.ts
+++ b/src/clauses/Call.test.ts
@@ -22,11 +22,11 @@ import Cypher from "..";
 describe("CypherBuilder Call", () => {
     test("Wraps query inside Call", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
-        const createQuery = new Cypher.Create(movieNode).set([movieNode.property("id"), idParam]).return(movieNode);
+        const createQuery = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+            .set([movieNode.property("id"), idParam])
+            .return(movieNode);
         const queryResult = new Cypher.Call(createQuery).build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
             "CALL {
@@ -45,11 +45,11 @@ describe("CypherBuilder Call", () => {
 
     test("Nested Call", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
-        const createQuery = new Cypher.Create(movieNode).set([movieNode.property("id"), idParam]).return(movieNode);
+        const createQuery = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+            .set([movieNode.property("id"), idParam])
+            .return(movieNode);
         const nestedCall = new Cypher.Call(createQuery);
         const call = new Cypher.Call(nestedCall);
         const queryResult = call.build();
@@ -72,9 +72,9 @@ describe("CypherBuilder Call", () => {
     });
 
     test("CALL with import with", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
@@ -98,9 +98,12 @@ describe("CypherBuilder Call", () => {
     });
 
     test("CALL with import with *", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node).return([node.property("title"), "movie"]);
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] })).return([
+            node.property("title"),
+            "movie",
+        ]);
 
         const clause = new Cypher.Call(matchClause).importWith("*");
         const queryResult = clause.build();
@@ -116,9 +119,12 @@ describe("CypherBuilder Call", () => {
     });
 
     test("CALL with import with * and extra fields", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node).return([node.property("title"), "movie"]);
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] })).return([
+            node.property("title"),
+            "movie",
+        ]);
 
         const clause = new Cypher.Call(matchClause).importWith(node, "*");
         const queryResult = clause.build();
@@ -134,9 +140,9 @@ describe("CypherBuilder Call", () => {
     });
 
     test("CALL with import with without parameters", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
@@ -159,9 +165,9 @@ describe("CypherBuilder Call", () => {
     });
 
     test("CALL with import with multiple parameters", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
@@ -185,9 +191,9 @@ describe("CypherBuilder Call", () => {
     });
 
     test("CALL with import with fails if import with is already set", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
@@ -198,9 +204,9 @@ describe("CypherBuilder Call", () => {
     });
 
     test("CALL with external with", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
@@ -224,9 +230,9 @@ describe("CypherBuilder Call", () => {
     });
 
     test("CALL with external with, set and remove", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return(node);
 
@@ -257,9 +263,9 @@ WITH *"
     });
 
     test("CALL with external with clause", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), "movie"]);
 
@@ -283,10 +289,10 @@ WITH *"
     });
 
     test("CALL with unwind", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
         const movie = new Cypher.Variable();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), movie]);
 
@@ -311,10 +317,10 @@ WITH *"
     });
 
     test("CALL with unwind passed as a clause", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
         const movie = new Cypher.Variable();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(new Cypher.Param("aa"), new Cypher.Param("bb")))
             .return([node.property("title"), movie]);
 
@@ -341,9 +347,9 @@ WITH *"
     });
 
     test("CALL with delete", () => {
-        const node = new Cypher.Node({ labels: ["Movie"] });
+        const node = new Cypher.Node();
 
-        const matchClause = new Cypher.Match(node)
+        const matchClause = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie"] }))
             .where(Cypher.eq(node.property("title"), new Cypher.Param("bb")))
             .return(node);
 
@@ -368,12 +374,12 @@ DELETE this0"
 
     test("Call returns a variable", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const variable = new Cypher.Variable();
-        const createQuery = new Cypher.Create(movieNode).set([movieNode.property("id"), idParam]).return(variable);
+        const createQuery = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+            .set([movieNode.property("id"), idParam])
+            .return(variable);
         const queryResult = new Cypher.Call(createQuery).return(variable).build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
 "CALL {
@@ -415,7 +421,7 @@ CALL {
 
         test("Call in transaction of rows", () => {
             const query = Cypher.concat(
-                new Cypher.Match(node),
+                new Cypher.Match(new Cypher.Pattern(node)),
                 new Cypher.Call(subquery).inTransactions({
                     ofRows: 10,
                 })
@@ -433,7 +439,7 @@ CALL {
 
         test("Call in transaction on error fail", () => {
             const query = Cypher.concat(
-                new Cypher.Match(node),
+                new Cypher.Match(new Cypher.Pattern(node)),
                 new Cypher.Call(subquery).inTransactions({
                     onError: "fail",
                 })
@@ -450,7 +456,7 @@ CALL {
         });
         test("Call in transaction on error break", () => {
             const query = Cypher.concat(
-                new Cypher.Match(node),
+                new Cypher.Match(new Cypher.Pattern(node)),
                 new Cypher.Call(subquery).inTransactions({
                     onError: "break",
                 })
@@ -468,7 +474,7 @@ CALL {
 
         test("Call in transaction on error continue", () => {
             const query = Cypher.concat(
-                new Cypher.Match(node),
+                new Cypher.Match(new Cypher.Pattern(node)),
                 new Cypher.Call(subquery).inTransactions({
                     onError: "continue",
                 })
@@ -489,7 +495,7 @@ CALL {
             const deleteSubquery = new Cypher.With(node).detachDelete(node);
 
             const query = Cypher.concat(
-                new Cypher.Match(node),
+                new Cypher.Match(new Cypher.Pattern(node)),
                 new Cypher.Call(deleteSubquery).inTransactions({
                     ofRows: 10,
                     onError: "fail",

--- a/src/clauses/Create.test.ts
+++ b/src/clauses/Create.test.ts
@@ -22,14 +22,15 @@ import Cypher from "..";
 describe("CypherBuilder Create", () => {
     test("Create Node", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const createQuery = new Cypher.Create(
-            new Cypher.Pattern(movieNode).withProperties({
-                test: new Cypher.Param("test-value"),
-                id: idParam,
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
             })
         )
             .set(
@@ -62,15 +63,18 @@ describe("CypherBuilder Create", () => {
         const testParam = new Cypher.Param(null);
         const nullStringParam = new Cypher.Param("null");
 
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const properties = {
             id: idParam,
         };
 
-        const createQuery = new Cypher.Create(new Cypher.Pattern(movieNode).withProperties(properties))
+        const createQuery = new Cypher.Create(
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties,
+            })
+        )
             .set([movieNode.property("test"), testParam], [movieNode.property("nullStr"), nullStringParam])
             .return(movieNode);
 
@@ -95,15 +99,22 @@ describe("CypherBuilder Create", () => {
         const testParam = new Cypher.Param(null);
         const nullStringParam = new Cypher.Param("null");
 
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const properties = {
             id: idParam,
         };
         const path = new Cypher.Path();
-        const createQuery = new Cypher.Create(new Cypher.Pattern(movieNode).withProperties(properties))
+        const createQuery = new Cypher.Create(
+            new Cypher.Pattern(
+                movieNode,
+
+                {
+                    labels: ["Movie"],
+                    properties,
+                }
+            )
+        )
             .assignToPath(path)
             .set([movieNode.property("test"), testParam], [movieNode.property("nullStr"), nullStringParam])
             .return(movieNode);
@@ -126,14 +137,15 @@ describe("CypherBuilder Create", () => {
 
     test("Create Node with empty set", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const createQuery = new Cypher.Create(
-            new Cypher.Pattern(movieNode).withProperties({
-                test: new Cypher.Param("test-value"),
-                id: idParam,
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
             })
         )
             .set()
@@ -155,14 +167,15 @@ describe("CypherBuilder Create", () => {
 
     test("Create with delete", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const createQuery = new Cypher.Create(
-            new Cypher.Pattern(movieNode).withProperties({
-                test: new Cypher.Param("test-value"),
-                id: idParam,
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
             })
         )
             .set(
@@ -192,14 +205,15 @@ DELETE this0"
 
     test("Create with detach delete", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const createQuery = new Cypher.Create(
-            new Cypher.Pattern(movieNode).withProperties({
-                test: new Cypher.Param("test-value"),
-                id: idParam,
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
             })
         )
             .set(
@@ -229,14 +243,15 @@ DETACH DELETE this0"
 
     test("Create with noDetach delete", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const createQuery = new Cypher.Create(
-            new Cypher.Pattern(movieNode).withProperties({
-                test: new Cypher.Param("test-value"),
-                id: idParam,
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
             })
         )
             .set(
@@ -266,14 +281,15 @@ NODETACH DELETE this0"
 
     test("Create with remove", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const createQuery = new Cypher.Create(
-            new Cypher.Pattern(movieNode).withProperties({
-                test: new Cypher.Param("test-value"),
-                id: idParam,
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
             })
         )
             .set(
@@ -308,9 +324,12 @@ REMOVE this0.title"
         });
 
         const createQuery = new Cypher.Create(
-            new Cypher.Pattern(movieNode).withProperties({
-                test: new Cypher.Param("test-value"),
-                id: idParam,
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
             })
         )
             .set(
@@ -342,16 +361,17 @@ RETURN this0"
 
     test("Chained create with existing create Clause", () => {
         const idParam = new Cypher.Param("my-id");
-        const movieNode = new Cypher.Node({
-            labels: ["Movie"],
-        });
+        const movieNode = new Cypher.Node();
 
         const secondCreate = new Cypher.Create(new Cypher.Node({ labels: ["Actor"] }));
 
         const createQuery = new Cypher.Create(
-            new Cypher.Pattern(movieNode).withProperties({
-                test: new Cypher.Param("test-value"),
-                id: idParam,
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
             })
         )
             .set(

--- a/src/clauses/Foreach.test.ts
+++ b/src/clauses/Foreach.test.ts
@@ -24,8 +24,11 @@ describe("Foreach", () => {
         const list = new Cypher.Literal([1, 2, 3]);
         const variable = new Cypher.Variable();
 
-        const movieNode = new Cypher.Node({ labels: ["Movie"] });
-        const createMovie = new Cypher.Create(movieNode).set([movieNode.property("id"), variable]);
+        const movieNode = new Cypher.Node();
+        const createMovie = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] })).set([
+            movieNode.property("id"),
+            variable,
+        ]);
 
         const foreachClause = new Cypher.Foreach(variable, list, createMovie).with("*");
 
@@ -46,8 +49,8 @@ describe("Foreach", () => {
         const list = new Cypher.Literal([1, 2, 3]);
         const variable = new Cypher.Variable();
 
-        const movieNode = new Cypher.Node({ labels: ["Movie"] });
-        const createMovie = new Cypher.Create(movieNode);
+        const movieNode = new Cypher.Node();
+        const createMovie = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] }));
 
         const foreachClause = new Cypher.Foreach(variable, list, createMovie)
             .remove(movieNode.property("title"))
@@ -74,8 +77,8 @@ WITH *"
         const list = new Cypher.Literal([1, 2, 3]);
         const variable = new Cypher.Variable();
 
-        const movieNode = new Cypher.Node({ labels: ["Movie"] });
-        const createMovie = new Cypher.Create(movieNode);
+        const movieNode = new Cypher.Node();
+        const createMovie = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] }));
 
         const foreachClause = new Cypher.Foreach(variable, list, createMovie).detachDelete(movieNode).with("*");
 


### PR DESCRIPTION
Plenty of tests still use the deprecated syntax `new Cypher.Match(node)` instead of the new `new Cypher.Match(new Cypher.Pattern(node))`

This PR updates tests on `Call`, `Create` and `Foreach`