### PR TITLE
Add support for concurrent transactions

### DIFF
--- a/.changeset/lovely-pots-end.md
+++ b/.changeset/lovely-pots-end.md
@@ -1,0 +1,17 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for `CALL { …​ } IN CONCURRENT TRANSACTIONS`:
+
+```js
+new Cypher.Call(subquery).inTransactions({
+    concurrentTransactions: 3,
+});
+```
+
+```cypher
+CALL {
+    // Subquery
+} IN 3 CONCURRENT TRANSACTIONS
+```

--- a/docs/modules/ROOT/pages/subqueries/call.adoc
+++ b/docs/modules/ROOT/pages/subqueries/call.adoc
@@ -95,3 +95,4 @@ The method `inTransaction` accepts an object with the following options:
 
 * `ofRows`: A number to define the batch of rows. Translates to `IN TRANSACTIONS OF 10 ROWS`
 * `onError`: A behavior for error handling. This can be `continue`, `break` or `fail`. Translates to `ON ERROR CONTINUE`
+* `concurrentTransactions`: A number to execute concurrent transactions. Translates to `IN x CONCURRENT TRANSACTIONS`

--- a/src/clauses/Call.test.ts
+++ b/src/clauses/Call.test.ts
@@ -505,5 +505,49 @@ CALL {
 } IN TRANSACTIONS OF 10 ROWS ON ERROR FAIL"
 `);
         });
+
+        test("Call in concurrent transaction", () => {
+            const node = new Cypher.Node();
+            const deleteSubquery = new Cypher.With(node).detachDelete(node);
+
+            const query = Cypher.concat(
+                new Cypher.Match(new Cypher.Pattern(node)),
+                new Cypher.Call(deleteSubquery).inTransactions({
+                    concurrentTransactions: 3,
+                })
+            );
+
+            const queryResult = query.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+CALL {
+    WITH this0
+    DETACH DELETE this0
+} IN 3 CONCURRENT TRANSACTIONS"
+`);
+        });
+
+        test("Call in concurrent transaction of rows and error", () => {
+            const node = new Cypher.Node();
+            const deleteSubquery = new Cypher.With(node).detachDelete(node);
+
+            const query = Cypher.concat(
+                new Cypher.Match(new Cypher.Pattern(node)),
+                new Cypher.Call(deleteSubquery).inTransactions({
+                    ofRows: 10,
+                    onError: "fail",
+                    concurrentTransactions: 5,
+                })
+            );
+
+            const queryResult = query.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+CALL {
+    WITH this0
+    DETACH DELETE this0
+} IN 5 CONCURRENT TRANSACTIONS OF 10 ROWS ON ERROR FAIL"
+`);
+        });
     });
 });

--- a/src/clauses/Call.ts
+++ b/src/clauses/Call.ts
@@ -51,6 +51,7 @@ export interface Call
 type InTransactionConfig = {
     ofRows?: number;
     onError?: "continue" | "break" | "fail";
+    concurrentTransactions?: number;
 };
 
 /**
@@ -138,7 +139,11 @@ export class Call extends Clause {
         const ofRowsStr = rows ? ` OF ${rows} ROWS` : "";
         const onErrorStr = error ? ` ON ERROR ${this.getOnErrorStr(error)}` : "";
 
-        return ` IN TRANSACTIONS${ofRowsStr}${onErrorStr}`;
+        const concurrentTransactions = this.inTransactionsConfig.concurrentTransactions;
+        const concurrentTransactionsStr =
+            typeof concurrentTransactions === "number" ? ` ${concurrentTransactions} CONCURRENT` : "";
+
+        return ` IN${concurrentTransactionsStr} TRANSACTIONS${ofRowsStr}${onErrorStr}`;
     }
 
     private getOnErrorStr(err: "continue" | "break" | "fail"): "CONTINUE" | "BREAK" | "FAIL" {


### PR DESCRIPTION

Add support for `CALL { …​ } IN CONCURRENT TRANSACTIONS`:

```js
new Cypher.Call(subquery).inTransactions({
    concurrentTransactions: 3,
});
```

```cypher
CALL {
    // Subquery
} IN 3 CONCURRENT TRANSACTIONS
```