### PR TITLE
Merge build options into a single object param

### DIFF
--- a/.changeset/khaki-lobsters-kiss.md
+++ b/.changeset/khaki-lobsters-kiss.md
@@ -1,0 +1,17 @@
+---
+"@neo4j/cypher-builder": major
+---
+
+Clause build options are now passed as an object rather than parameters:
+
+```js
+myClause.build({
+    prefix: "another-this",
+    extraParams: {
+        myParam: "hello",
+    },
+    labelOperator: "&",
+});
+```
+
+All parameters are optional, and `build` can still be called without parameters

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -37,13 +37,19 @@ export abstract class Clause extends CypherASTNode {
     protected nextClause: Clause | undefined;
 
     /** Compiles a clause into Cypher and params */
-    public build(
-        prefix?: string | EnvPrefix | undefined,
-        extraParams: Record<string, unknown> = {},
-        config?: BuildConfig
-    ): CypherResult {
+    public build({
+        prefix,
+        extraParams = {},
+        labelOperator = ":",
+    }: {
+        prefix?: string | EnvPrefix | undefined;
+        extraParams?: Record<string, unknown>;
+        labelOperator?: ":" | "&";
+    } = {}): CypherResult {
         if (this.isRoot) {
-            const env = this.getEnv(prefix, config);
+            const env = this.getEnv(prefix, {
+                labelOperator,
+            });
             const cypher = this.getCypher(env);
 
             const cypherParams = toCypherParams(extraParams);
@@ -55,7 +61,7 @@ export abstract class Clause extends CypherASTNode {
         }
         const root = this.getRoot();
         if (root instanceof Clause) {
-            return root.build(prefix, extraParams);
+            return root.build({ prefix, extraParams, labelOperator });
         }
         throw new Error(`Cannot build root: ${root.constructor.name}`);
     }

--- a/tests/config/extraParams.test.ts
+++ b/tests/config/extraParams.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../../src";
+
+describe("Extra Params", () => {
+    test("Adding extra params to build options", () => {
+        const movieNode = new Cypher.Node();
+        const pattern = new Cypher.Pattern(movieNode, { labels: ["Movie"] });
+
+        const matchQuery = new Cypher.Match(pattern)
+            .where(movieNode, {
+                title: new Cypher.Param("The Matrix"),
+            })
+            .return(movieNode.property("title"));
+
+        const { cypher, params } = matchQuery.build({
+            extraParams: {
+                myExtraParam1: "Extra Param",
+            },
+        });
+
+        expect(cypher).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            WHERE this0.title = $param0
+            RETURN this0.title"
+        `);
+        expect(params).toMatchInlineSnapshot(`
+{
+  "myExtraParam1": "Extra Param",
+  "param0": "The Matrix",
+}
+`);
+    });
+
+    test("Adding extra params with conflict to build options", () => {
+        const movieNode = new Cypher.Node();
+        const pattern = new Cypher.Pattern(movieNode, { labels: ["Movie"] });
+
+        const matchQuery = new Cypher.Match(pattern)
+            .where(movieNode, {
+                title: new Cypher.Param("The Matrix"),
+            })
+            .return(movieNode.property("title"));
+
+        const { cypher, params } = matchQuery.build({
+            extraParams: {
+                param0: "Extra Param",
+            },
+        });
+
+        expect(cypher).toMatchInlineSnapshot(`
+            "MATCH (this0:Movie)
+            WHERE this0.title = $param0
+            RETURN this0.title"
+        `);
+        expect(params).toMatchInlineSnapshot(`
+{
+  "param0": "Extra Param",
+}
+`);
+    });
+});

--- a/tests/config/labelOperator.test.ts
+++ b/tests/config/labelOperator.test.ts
@@ -21,15 +21,13 @@ import Cypher from "../../src";
 import { TestClause } from "../../src/utils/TestClause";
 
 describe.each([":", "&"] as const)("Config.labelOperator", (labelOperator) => {
-    const config: Cypher.BuildConfig = {
-        labelOperator,
-    };
-
     test("Pattern", () => {
         const node = new Cypher.Node();
         const query = new Cypher.Match(new Cypher.Pattern(node, { labels: ["Movie", "Film"] }));
 
-        const queryResult = new TestClause(query).build(undefined, {}, config);
+        const queryResult = new TestClause(query).build({
+            labelOperator,
+        });
 
         expect(queryResult.cypher).toBe(`MATCH (this0:Movie${labelOperator}Film)`);
     });
@@ -40,7 +38,9 @@ describe.each([":", "&"] as const)("Config.labelOperator", (labelOperator) => {
             node.hasLabels("Movie", "Film")
         );
 
-        const queryResult = new TestClause(query).build(undefined, {}, config);
+        const queryResult = new TestClause(query).build({
+            labelOperator,
+        });
 
         expect(queryResult.cypher).toBe(`MATCH (this0:Movie)
 WHERE this0:Movie${labelOperator}Film`);

--- a/tests/variable-escaping.test.ts
+++ b/tests/variable-escaping.test.ts
@@ -66,7 +66,7 @@ describe("Variable escaping", () => {
         const movie = new Cypher.Node();
         const match = new Cypher.Match(new Cypher.Pattern(movie, { labels: ["My Movie"] })).return(movie);
 
-        const { cypher, params } = match.build("my prefix");
+        const { cypher, params } = match.build({ prefix: "my prefix" });
 
         expect(cypher).toMatchInlineSnapshot(`
             "MATCH (\`my prefixthis0\`:\`My Movie\`)


### PR DESCRIPTION
Clause build options are now passed as an object rather than parameters:

```js
myClause.build({
    prefix: "another-this",
    extraParams: {
        myParam: "hello",
    },
    labelOperator: "&",
});
```

All parameters are optional, and `build` can still be called without parameters