### PR TITLE
Chain call

### DIFF
--- a/.changeset/early-rocks-talk.md
+++ b/.changeset/early-rocks-talk.md
@@ -1,0 +1,19 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Add support for adding `Call` clauses to `Match` and `With`:
+
+```js
+const match = new Cypher.Match(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+    .call(new Cypher.Create(new Cypher.Pattern(movieNode).related().to(actorNode)), [movieNode])
+    .return(movieNode);
+```
+
+```cypher
+MATCH (this0:Movie)
+CALL (this0) {
+    CREATE (this0)-[this2]->(this1)
+}
+RETURN this0
+```

--- a/package.json
+++ b/package.json
@@ -58,6 +58,5 @@
         "ts-jest": "^29.2.4",
         "typedoc": "^0.26.5",
         "typescript": "^5.5.4"
-    },
-    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
+    }
 }

--- a/src/clauses/Call.test.ts
+++ b/src/clauses/Call.test.ts
@@ -407,7 +407,10 @@ RETURN var1"
         });
 
         test("Call in transaction", () => {
-            const query = Cypher.concat(new Cypher.Match(node), new Cypher.Call(subquery).inTransactions());
+            const query = Cypher.concat(
+                new Cypher.Match(new Cypher.Pattern(node)),
+                new Cypher.Call(subquery).inTransactions()
+            );
 
             const queryResult = query.build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -722,4 +722,27 @@ RETURN var1"
 `);
         });
     });
+
+    describe("Match.call", () => {
+        test("Match.Call with variable scope", () => {
+            const movieNode = new Cypher.Node();
+            const actorNode = new Cypher.Node();
+
+            const match = new Cypher.Match(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+                .match(new Cypher.Pattern(actorNode, { labels: ["Actor"] }))
+                .call(new Cypher.Create(new Cypher.Pattern(movieNode).related().to(actorNode)), [movieNode, actorNode])
+                .return(movieNode);
+
+            const { cypher, params } = match.build();
+            expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+MATCH (this1:Actor)
+CALL (this0, this1) {
+    CREATE (this0)-[this2]->(this1)
+}
+RETURN this0"
+`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
+    });
 });

--- a/src/clauses/Match.ts
+++ b/src/clauses/Match.ts
@@ -24,6 +24,7 @@ import { NodeRef } from "../references/NodeRef";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
 import { Clause } from "./Clause";
 import { WithPathAssign } from "./mixins/WithPathAssign";
+import { WithCall } from "./mixins/clauses/WithCall";
 import { WithCallProcedure } from "./mixins/clauses/WithCallProcedure";
 import { WithCreate } from "./mixins/clauses/WithCreate";
 import { WithFinish } from "./mixins/clauses/WithFinish";
@@ -49,7 +50,8 @@ export interface Match
         WithCreate,
         WithMerge,
         WithFinish,
-        WithCallProcedure {}
+        WithCallProcedure,
+        WithCall {}
 
 /**
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/match/)
@@ -67,7 +69,8 @@ export interface Match
     WithCreate,
     WithMerge,
     WithFinish,
-    WithCallProcedure
+    WithCallProcedure,
+    WithCall
 )
 export class Match extends Clause {
     private pattern: Pattern | QuantifiedPath;

--- a/src/clauses/Match.ts
+++ b/src/clauses/Match.ts
@@ -74,7 +74,7 @@ export class Match extends Clause {
     private _optional = false;
 
     constructor(pattern: Pattern | QuantifiedPath);
-    /** @deprecated Use {@link Pattern} instead */
+    /** @deprecated Use {@link Pattern} instead of node: `new Cypher.Match(new Cypher.Pattern(node))` */
     constructor(node: NodeRef | Pattern | QuantifiedPath);
     constructor(pattern: NodeRef | Pattern | QuantifiedPath) {
         super();

--- a/src/clauses/With.test.ts
+++ b/src/clauses/With.test.ts
@@ -282,4 +282,25 @@ CALL apoc.util.validate(true, \\"message\\", [0])"
             expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });
     });
+
+    describe("Match.call", () => {
+        test("Match.Call with variable scope", () => {
+            const movieNode = new Cypher.Node();
+            const actorNode = new Cypher.Node();
+
+            const match = new Cypher.With(movieNode)
+                .call(new Cypher.Create(new Cypher.Pattern(movieNode).related().to(actorNode)), [movieNode])
+                .return(actorNode);
+
+            const { cypher, params } = match.build();
+            expect(cypher).toMatchInlineSnapshot(`
+"WITH this0
+CALL (this0) {
+    CREATE (this0)-[this1]->(this2)
+}
+RETURN this2"
+`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
+    });
 });

--- a/src/clauses/With.ts
+++ b/src/clauses/With.ts
@@ -23,6 +23,7 @@ import type { Variable } from "../references/Variable";
 import type { Expr } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
 import { Clause } from "./Clause";
+import { WithCall } from "./mixins/clauses/WithCall";
 import { WithCallProcedure } from "./mixins/clauses/WithCallProcedure";
 import { WithCreate } from "./mixins/clauses/WithCreate";
 import { WithMatch } from "./mixins/clauses/WithMatch";
@@ -47,13 +48,25 @@ export interface With
         WithUnwind,
         WithCreate,
         WithMerge,
-        WithCallProcedure {}
+        WithCallProcedure,
+        WithCall {}
 
 /**
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/with/)
  * @category Clauses
  */
-@mixin(WithOrder, WithReturn, WithWhere, WithDelete, WithMatch, WithUnwind, WithCreate, WithMerge, WithCallProcedure)
+@mixin(
+    WithOrder,
+    WithReturn,
+    WithWhere,
+    WithDelete,
+    WithMatch,
+    WithUnwind,
+    WithCreate,
+    WithMerge,
+    WithCallProcedure,
+    WithCall
+)
 export class With extends Clause {
     private projection: Projection;
     private isDistinct = false;

--- a/src/clauses/mixins/clauses/WithCall.ts
+++ b/src/clauses/mixins/clauses/WithCall.ts
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Clause, Variable } from "../../..";
+import { Call } from "../../..";
+import { MixinClause } from "../Mixin";
+
+export abstract class WithCall extends MixinClause {
+    /** Add a {@link Call} clause
+     * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/subqueries/call-subquery/)
+     */
+    public call(subquery: Clause, variableScope?: Variable[] | "*"): Call {
+        const callClause = new Call(subquery, variableScope);
+        this.addNextClause(callClause);
+
+        return callClause;
+    }
+}


### PR DESCRIPTION
Add support for adding `Call` clauses to `Match` and `With`:

```js
const match = new Cypher.Match(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
    .call(new Cypher.Create(new Cypher.Pattern(movieNode).related().to(actorNode)), [movieNode])
    .return(movieNode);
```

```cypher
MATCH (this0:Movie)
CALL (this0) {
    CREATE (this0)-[this2]->(this1)
}
RETURN this0
```


This should reduce the need of `Cypher.concat` 