### PR TITLE
Remove deprecated cypher.concat

### DIFF
--- a/.changeset/pink-geckos-tie.md
+++ b/.changeset/pink-geckos-tie.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": major
+---
+
+Remove method `Cypher.concat`, `Cypher.utils.concat` should be used instead

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -32,8 +32,6 @@ export { Unwind } from "./clauses/Unwind";
 export { Use } from "./clauses/Use";
 export { With } from "./clauses/With";
 
-export { concat } from "./clauses/utils/concat";
-
 // Patterns
 export { labelExpr } from "./expressions/labels/label-expressions";
 export { Pattern } from "./pattern/Pattern";

--- a/src/clauses/utils/concat.ts
+++ b/src/clauses/utils/concat.ts
@@ -92,11 +92,3 @@ export class CompositeClause extends Clause {
         } else return clause;
     }
 }
-
-/** Concatenates multiple {@link Clause | clauses} into a single clause
- * @category Clauses
- * @deprecated Use `Cypher.utils.concat` instead
- */
-export function concat(...clauses: Array<Clause | undefined>): CompositeClause {
-    return new CompositeClause(clauses, "\n");
-}


### PR DESCRIPTION
Remove method `Cypher.concat`, `Cypher.utils.concat` should be used instead