### PR TITLE
Escape literals

### DIFF
--- a/.changeset/long-coats-drop.md
+++ b/.changeset/long-coats-drop.md
@@ -1,0 +1,15 @@
+---
+"@neo4j/cypher-builder": major
+---
+
+Escape literal strings if they contain invalid characters:
+
+```js
+new Cypher.Literal(`Hello "World"`);
+```
+
+Would get translated into the following Cypher:
+
+```cypher
+"Hello \"World\""
+```

--- a/src/references/Literal.test.ts
+++ b/src/references/Literal.test.ts
@@ -30,6 +30,15 @@ describe("Literal", () => {
         expect(queryResult.cypher).toBe(`"hello"`);
     });
 
+    test("Serialize string value escaping it", () => {
+        const stringLiteral = new Cypher.Literal(`he"llo`);
+
+        const testClause = new TestClause(stringLiteral);
+
+        const queryResult = testClause.build();
+        expect(queryResult.cypher).toBe(`"he\\"llo"`);
+    });
+
     test("Serialize boolean value", () => {
         const booleanLiteral = new Cypher.Literal(true);
 
@@ -55,6 +64,15 @@ describe("Literal", () => {
 
         const queryResult = testClause.build();
         expect(queryResult.cypher).toBe(`["hello", 5, "hello"]`);
+    });
+
+    test("Serialize array escaping values", () => {
+        const literal = new Cypher.Literal(["hello", 5, 'hel""lo']);
+
+        const testClause = new TestClause(literal);
+
+        const queryResult = testClause.build();
+        expect(queryResult.cypher).toBe(`["hello", 5, "hel\\"\\"lo"]`);
     });
 
     test("Serialize null", () => {

--- a/src/references/Literal.ts
+++ b/src/references/Literal.ts
@@ -18,6 +18,7 @@
  */
 
 import type { CypherCompilable } from "../types";
+import { escapeLiteralString } from "../utils/escape";
 
 type LiteralValue = string | number | boolean | null | Array<LiteralValue>;
 
@@ -38,7 +39,7 @@ export class Literal<T extends LiteralValue = LiteralValue> implements CypherCom
 
     private formatLiteralValue(value: LiteralValue): string {
         if (typeof value === "string") {
-            return `"${value}"`;
+            return `"${escapeLiteralString(value)}"`;
         }
         if (value === null) {
             return "NULL";

--- a/src/utils/escape.test.ts
+++ b/src/utils/escape.test.ts
@@ -18,6 +18,7 @@
  */
 
 import Cypher from "..";
+import { escapeLiteralString } from "./escape";
 
 describe("escaping", () => {
     describe.each(["escapeVariable", "escapeLabel", "escapeType", "escapeProperty"] as const)("utils.%s()", (func) => {
@@ -36,6 +37,20 @@ describe("escaping", () => {
             ["0this", "`0this`"],
         ])("Escape '%s'", (original, expected) => {
             expect(Cypher.utils[func](original)).toBe(expected);
+        });
+    });
+
+    describe("escapeLiteralString", () => {
+        test("Does not escape empty strings", () => {
+            expect(escapeLiteralString("")).toBe("");
+        });
+
+        test.each([[`my "var"`, `my \\"var\\"`, `my \\"var`, `my \\\\"var`]])("Escape '%s'", (original, expected) => {
+            expect(escapeLiteralString(original)).toBe(expected);
+        });
+
+        test.each(["this", "_var", "hello` dsa"])("Does not escape '%s'", (value) => {
+            expect(escapeLiteralString(value)).toBe(value);
         });
     });
 });

--- a/src/utils/escape.ts
+++ b/src/utils/escape.ts
@@ -39,10 +39,16 @@ export function escapeVariable(varName: string): string {
     return escapeIfNeeded(varName);
 }
 
+/** Escapes a literal string */
+export function escapeLiteralString(str: string): string {
+    return str.replaceAll(`"`, `\\"`);
+}
+
 function escapeIfNeeded(str: string): string {
     const normalizedStr = normalizeString(str);
     if (needsEscape(normalizedStr)) {
-        return escapeString(normalizedStr);
+        const escapedLabel = normalizedStr.replace(ESCAPE_SYMBOL_REGEX, "``");
+        return `\`${escapedLabel}\``;
     }
     return normalizedStr;
 }
@@ -55,9 +61,4 @@ function needsEscape(str: string): boolean {
     if (!str) return false;
     const validStr = /^[a-z_][0-9a-z_]*$/i;
     return !validStr.test(str);
-}
-
-function escapeString(normalizedStr: string): string {
-    const escapedLabel = normalizedStr.replace(ESCAPE_SYMBOL_REGEX, "``");
-    return `\`${escapedLabel}\``;
 }


### PR DESCRIPTION
Escape literal strings if they contain invalid characters:

```js
new Cypher.Literal(`Hello "World"`);
```

Would get translated into the following Cypher:

```cypher
"Hello \"World\""
```