### PR TITLE
412 shortest matching patterns

### DIFF
--- a/.changeset/forty-chefs-glow.md
+++ b/.changeset/forty-chefs-glow.md
@@ -1,0 +1,21 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for SHORTEST keyword in match and its variations:
+
+-   `.shortest(k)`
+-   `.shortestGroups(k)`
+-   `.allShortest`
+-   `.any`
+
+For example:
+
+```js
+new Cypher.Match(pattern).shortest(2).return(node);
+```
+
+```cypher
+MATCH ALL SHORTEST (this0:Movie)-[this1]->(this2:Person)
+RETURN this0
+```

--- a/docs/modules/ROOT/pages/clauses/match.adoc
+++ b/docs/modules/ROOT/pages/clauses/match.adoc
@@ -60,3 +60,37 @@ const pattern = new Cypher.Pattern(movie, { labels: ["Movie"] });
 
 const matchQuery = new Cypher.Match(pattern).optional();
 ----
+
+== Shortest paths
+
+link:https://neo4j.com/docs/cypher-manual/current/patterns/shortest-paths/#shortest[Shortest paths] and its variations can be added in a Match clause with the following methods in `Cypher.Match`:
+
+* `.shortest(k)`
+* `.shortestGroups(k)`
+* `.allShortest`
+* `.any`
+
+For example:
+
+[source, javascript]
+----
+const movieNode = new Cypher.Node();
+
+const matchQuery = new Cypher.Match(
+    new Cypher.Pattern(movieNode, {
+        labels: ["Movie"]
+    })
+        .related()
+        .to(new Cypher.Node(), {
+            labels: ["Person"],
+        })
+)
+    .shortestGroups(2)
+    .return(movieNode);
+----
+
+[source, cypher]
+----
+MATCH SHORTEST 2 GROUPS (this0:Movie)-[this1]->(this2:Person)
+RETURN this0
+----

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -869,11 +869,11 @@ RETURN this0"
                 })
             );
 
-            const query = new Cypher.Match(quantifiedPath).return(m2);
+            const query = new Cypher.Match(quantifiedPath).shortest(2).return(m2);
             const queryResult = query.build();
 
             expect(queryResult.cypher).toMatchInlineSnapshot(`
-    "MATCH (this0:Movie { title: $param0 })
+    "MATCH SHORTEST 2 (this0:Movie { title: $param0 })
           ((:Movie)-[:ACTED_IN]->(:Person)){1,2}
           (this1:Movie { title: $param1 })
     RETURN this1"

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -745,4 +745,145 @@ RETURN this0"
             expect(params).toMatchInlineSnapshot(`{}`);
         });
     });
+
+    describe("SHORTEST paths", () => {
+        test("SHORTEST k", () => {
+            const movieNode = new Cypher.Node();
+
+            const matchQuery = new Cypher.Match(
+                new Cypher.Pattern(movieNode, {
+                    labels: ["Movie"],
+                    properties: {
+                        test: new Cypher.Param("test-value"),
+                    },
+                })
+                    .related()
+                    .to(new Cypher.Node(), {
+                        labels: ["Person"],
+                    })
+            )
+                .shortest(2)
+                .return(movieNode);
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH SHORTEST 2 (this0:Movie { test: $param0 })-[this1]->(this2:Person)
+RETURN this0"
+`);
+        });
+
+        test("SHORTEST k GROUPS", () => {
+            const movieNode = new Cypher.Node();
+
+            const matchQuery = new Cypher.Match(
+                new Cypher.Pattern(movieNode, {
+                    labels: ["Movie"],
+                    properties: {
+                        test: new Cypher.Param("test-value"),
+                    },
+                })
+                    .related()
+                    .to(new Cypher.Node(), {
+                        labels: ["Person"],
+                    })
+            )
+                .shortestGroups(2)
+                .return(movieNode);
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH SHORTEST 2 GROUPS (this0:Movie { test: $param0 })-[this1]->(this2:Person)
+RETURN this0"
+`);
+        });
+
+        test("ALL SHORTEST", () => {
+            const movieNode = new Cypher.Node();
+
+            const matchQuery = new Cypher.Match(
+                new Cypher.Pattern(movieNode, {
+                    labels: ["Movie"],
+                    properties: {
+                        test: new Cypher.Param("test-value"),
+                    },
+                })
+                    .related()
+                    .to(new Cypher.Node(), {
+                        labels: ["Person"],
+                    })
+            )
+                .allShortest()
+                .return(movieNode);
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH ALL SHORTEST (this0:Movie { test: $param0 })-[this1]->(this2:Person)
+RETURN this0"
+`);
+        });
+
+        test("ANY", () => {
+            const movieNode = new Cypher.Node();
+
+            const matchQuery = new Cypher.Match(
+                new Cypher.Pattern(movieNode, {
+                    labels: ["Movie"],
+                    properties: {
+                        test: new Cypher.Param("test-value"),
+                    },
+                })
+                    .related()
+                    .to(new Cypher.Node(), {
+                        labels: ["Person"],
+                    })
+            )
+                .any()
+                .return(movieNode);
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH ANY (this0:Movie { test: $param0 })-[this1]->(this2:Person)
+RETURN this0"
+`);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`
+                {
+                  "param0": "test-value",
+                }
+            `);
+        });
+
+        test("SHORTEST with quantified path", () => {
+            const m = new Cypher.Node();
+            const m2 = new Cypher.Node();
+
+            const quantifiedPath = new Cypher.QuantifiedPath(
+                new Cypher.Pattern(m, { labels: ["Movie"], properties: { title: new Cypher.Param("V for Vendetta") } }),
+                new Cypher.Pattern({ labels: ["Movie"] })
+                    .related({ type: "ACTED_IN" })
+                    .to({ labels: ["Person"] })
+                    .quantifier({ min: 1, max: 2 }),
+                new Cypher.Pattern(m2, {
+                    labels: ["Movie"],
+                    properties: { title: new Cypher.Param("Something's Gotta Give") },
+                })
+            );
+
+            const query = new Cypher.Match(quantifiedPath).return(m2);
+            const queryResult = query.build();
+
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+    "MATCH (this0:Movie { title: $param0 })
+          ((:Movie)-[:ACTED_IN]->(:Person)){1,2}
+          (this1:Movie { title: $param1 })
+    RETURN this1"
+    `);
+            expect(queryResult.params).toMatchInlineSnapshot(`
+    {
+      "param0": "V for Vendetta",
+      "param1": "Something's Gotta Give",
+    }
+    `);
+        });
+    });
 });


### PR DESCRIPTION
Add support for SHORTEST keyword in match and its variations:

-   `.shortest(k)`
-   `.shortestGroups(k)`
-   `.allShortest`
-   `.any`

For example:

```js
new Cypher.Match(pattern).shortest(2).return(node);
```

```cypher
MATCH ALL SHORTEST (this0:Movie)-[this1]->(this2:Person)
RETURN this0
```