### PR TITLE
Add support for set and remove labels

### DIFF
--- a/.changeset/rude-gorillas-add.md
+++ b/.changeset/rude-gorillas-add.md
@@ -1,0 +1,16 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for labels in set and remove:
+
+```js
+const movie = new Cypher.Node();
+const clause = new Cypher.Match(new Cypher.Pattern(movie)).set(movie.label("NewLabel"));
+```
+
+```cypher
+MATCH (this0)
+SET
+    this0:NewLabel
+```

--- a/docs/modules/ROOT/content-nav.adoc
+++ b/docs/modules/ROOT/content-nav.adoc
@@ -31,5 +31,6 @@
 ** xref:how-to/conditional-expressions.adoc[]
 ** xref:how-to/use-change-data-capture.adoc[]
 ** xref:how-to/type-predicate-expressions.adoc[]
+** xref:how-to/update-labels.adoc[]
 * link:https://github.com/neo4j/cypher-builder/tree/main/examples[Examples]
 * link:https://neo4j.github.io/cypher-builder/reference/[Reference]

--- a/docs/modules/ROOT/pages/how-to/update-labels.adoc
+++ b/docs/modules/ROOT/pages/how-to/update-labels.adoc
@@ -1,0 +1,43 @@
+[[update-labels]]
+:description: This page describes how to add or remove labels to a node.
+= Update Labels
+
+To add or remove labels to a node, use `.set` and `.remove` with the node method `.label`.
+
+
+== Examples
+
+=== Add labels
+
+[source, javascript]
+----
+const movie = new Cypher.Node();
+const clause = new Cypher.Match(new Cypher.Pattern(movie)).set(movie.label("NewLabel"), movie.label("Another label"));
+----
+
+
+[source, cypher]
+----
+MATCH (this0)
+SET
+    this0:NewLabel,
+    this0:`Another Label`
+----
+
+
+=== Remove labels
+
+
+[source, javascript]
+----
+const movie = new Cypher.Node();
+const clause = new Cypher.Match(new Cypher.Pattern(movie)).remove(movie.label("NewLabel"));
+----
+
+
+[source, cypher]
+----
+MATCH (this0)
+REMOVE this0:NewLabel
+----
+

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -176,6 +176,7 @@ export type { LabelExpr, LabelOperator } from "./expressions/labels/label-expres
 export type { BooleanOp } from "./expressions/operations/boolean";
 export type { ComparisonOp } from "./expressions/operations/comparison";
 export type { Yield } from "./procedures/Yield";
+export type { Label } from "./references/Label";
 export type { CypherResult, Expr, NormalizationType, Operation, Predicate } from "./types";
 export type { InputArgument } from "./utils/normalize-variable";
 

--- a/src/clauses/mixins/sub-clauses/WithRemove.ts
+++ b/src/clauses/mixins/sub-clauses/WithRemove.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import type { Label } from "../../..";
 import type { PropertyRef } from "../../../references/PropertyRef";
 import { RemoveClause } from "../../sub-clauses/Remove";
 import { Mixin } from "../Mixin";
@@ -27,7 +28,7 @@ export abstract class WithRemove extends Mixin {
     /** Append a `REMOVE` clause.
      * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/remove/)
      */
-    public remove(...properties: PropertyRef[]): this {
+    public remove(...properties: Array<PropertyRef | Label>): this {
         this.removeClause = new RemoveClause(this, properties);
         return this;
     }

--- a/src/clauses/sub-clauses/Remove.test.ts
+++ b/src/clauses/sub-clauses/Remove.test.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../..";
+
+describe("Remove", () => {
+    test("Remove labels", () => {
+        const movie = new Cypher.Node();
+        const clause = new Cypher.Match(new Cypher.Pattern(movie)).remove(movie.label("NewLabel"));
+
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+REMOVE this0:NewLabel"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("Remove multiple labels of a relationship", () => {
+        const movie = new Cypher.Node();
+        const actor = new Cypher.Node();
+        const clause = new Cypher.Match(new Cypher.Pattern(movie).related().to(actor)).remove(
+            movie.label("NewLabel"),
+            actor.label("Another Label")
+        );
+
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)-[this1]->(this2)
+REMOVE this0:NewLabel,this2:\`Another Label\`"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+});

--- a/src/clauses/sub-clauses/Remove.ts
+++ b/src/clauses/sub-clauses/Remove.ts
@@ -17,16 +17,15 @@
  * limitations under the License.
  */
 
+import type { Label } from "../..";
 import { CypherASTNode } from "../../CypherASTNode";
 import type { CypherEnvironment } from "../../Environment";
 import type { PropertyRef } from "../../references/PropertyRef";
 
-export type RemoveInput = Array<PropertyRef>;
-
 export class RemoveClause extends CypherASTNode {
-    private removeInput: RemoveInput;
+    private removeInput: Array<PropertyRef | Label>;
 
-    constructor(parent: CypherASTNode | undefined, removeInput: RemoveInput) {
+    constructor(parent: CypherASTNode | undefined, removeInput: Array<PropertyRef | Label>) {
         super(parent);
         this.removeInput = removeInput;
     }

--- a/src/clauses/sub-clauses/Remove.ts
+++ b/src/clauses/sub-clauses/Remove.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import type { Label } from "../..";
+import type { Label } from "../../references/Label";
 import { CypherASTNode } from "../../CypherASTNode";
 import type { CypherEnvironment } from "../../Environment";
 import type { PropertyRef } from "../../references/PropertyRef";

--- a/src/clauses/sub-clauses/Set.test.ts
+++ b/src/clauses/sub-clauses/Set.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../..";
+
+describe("Set", () => {
+    test("Set labels", () => {
+        const movie = new Cypher.Node();
+        const clause = new Cypher.Match(new Cypher.Pattern(movie)).set(movie.label("NewLabel"));
+
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+SET
+    this0:NewLabel"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("Set multiple labels", () => {
+        const movie = new Cypher.Node();
+        const clause = new Cypher.Match(new Cypher.Pattern(movie)).set(
+            movie.label("NewLabel"),
+            movie.label("Another Label")
+        );
+
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+SET
+    this0:NewLabel,
+    this0:\`Another Label\`"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("Set multiple labels of a relationship", () => {
+        const movie = new Cypher.Node();
+        const actor = new Cypher.Node();
+        const clause = new Cypher.Match(new Cypher.Pattern(movie).related().to(actor)).set(
+            movie.label("NewLabel"),
+            actor.label("Another Label")
+        );
+
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)-[this1]->(this2)
+SET
+    this0:NewLabel,
+    this2:\`Another Label\`"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+});

--- a/src/clauses/sub-clauses/Set.ts
+++ b/src/clauses/sub-clauses/Set.ts
@@ -20,12 +20,13 @@
 import { CypherASTNode } from "../../CypherASTNode";
 import type { CypherEnvironment } from "../../Environment";
 import type { MapExpr } from "../../expressions/map/MapExpr";
+import type { MapProjection } from "../../expressions/map/MapProjection";
+import { Label } from "../../references/Label";
 import type { PropertyRef } from "../../references/PropertyRef";
 import type { Expr } from "../../types";
 import { padBlock } from "../../utils/pad-block";
-import type { MapProjection } from "../../expressions/map/MapProjection";
 
-export type SetParam = [PropertyRef, Exclude<Expr, MapExpr | MapProjection>];
+export type SetParam = [PropertyRef, Exclude<Expr, MapExpr | MapProjection>] | Label;
 
 export class SetClause extends CypherASTNode {
     protected params: SetParam[];
@@ -51,7 +52,12 @@ export class SetClause extends CypherASTNode {
         return `SET\n${padBlock(paramsStr)}`;
     }
 
-    private composeParam(env: CypherEnvironment, [ref, param]: SetParam): string {
-        return `${ref.getCypher(env)} = ${param.getCypher(env)}`;
+    private composeParam(env: CypherEnvironment, setParam: SetParam): string {
+        if (setParam instanceof Label) {
+            return setParam.getCypher(env);
+        } else {
+            const [ref, param] = setParam;
+            return `${ref.getCypher(env)} = ${param.getCypher(env)}`;
+        }
     }
 }

--- a/src/expressions/labels/label-expressions.ts
+++ b/src/expressions/labels/label-expressions.ts
@@ -24,8 +24,6 @@ import { escapeLabel } from "../../utils/escape";
 
 export type LabelOperator = "&" | "|" | "!" | "%";
 
-type Label = string | LabelExpr;
-
 /**
  * Label Expression
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/expressions/#label-expressions)
@@ -43,7 +41,7 @@ export abstract class LabelExpr implements CypherCompilable {
      */
     public abstract getCypher(env: Environment): string;
 
-    protected compileLabel(expr: Label, env: Environment) {
+    protected compileLabel(expr: string | LabelExpr, env: Environment) {
         if (typeof expr === "string") {
             return escapeLabel(expr);
         }
@@ -52,9 +50,9 @@ export abstract class LabelExpr implements CypherCompilable {
 }
 
 class BinaryLabelExpr extends LabelExpr {
-    private labels: Label[];
+    private labels: Array<string | LabelExpr>;
 
-    constructor(operator: "&" | "|", labels: Label[]) {
+    constructor(operator: "&" | "|", labels: Array<string | LabelExpr>) {
         super(operator);
         this.labels = labels;
     }
@@ -71,9 +69,9 @@ class BinaryLabelExpr extends LabelExpr {
 }
 
 class NotLabelExpr extends LabelExpr {
-    private label: Label;
+    private label: string | LabelExpr;
 
-    constructor(label: Label) {
+    constructor(label: string | LabelExpr) {
         super("!");
         this.label = label;
     }
@@ -106,7 +104,7 @@ class WildcardLabelExpr extends LabelExpr {
  * @group Expressions
  * @category Operators
  */
-function labelAnd(...labels: Label[]): LabelExpr {
+function labelAnd(...labels: Array<string | LabelExpr>): LabelExpr {
     return new BinaryLabelExpr("&", labels);
 }
 
@@ -115,7 +113,7 @@ function labelAnd(...labels: Label[]): LabelExpr {
  * @group Expressions
  * @category Operators
  */
-function labelOr(...labels: Label[]): LabelExpr {
+function labelOr(...labels: Array<string | LabelExpr>): LabelExpr {
     return new BinaryLabelExpr("|", labels);
 }
 
@@ -124,7 +122,7 @@ function labelOr(...labels: Label[]): LabelExpr {
  * @group Expressions
  * @category Operators
  */
-function labelNot(label: Label): LabelExpr {
+function labelNot(label: string | LabelExpr): LabelExpr {
     return new NotLabelExpr(label);
 }
 

--- a/src/references/Label.ts
+++ b/src/references/Label.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CypherASTNode } from "../CypherASTNode";
+import type { CypherEnvironment } from "../Environment";
+import type { NodeRef } from "../references/NodeRef";
+import { addLabelToken } from "../utils/add-label-token";
+import { escapeLabel } from "../utils/escape";
+
+/** A node Label
+ * @group Other
+ * @example `:Movie`
+ */
+export class Label extends CypherASTNode {
+    private node: NodeRef;
+    private label: string;
+
+    /**
+     * @hidden
+     */
+    constructor(node: NodeRef, label: string) {
+        super();
+        this.node = node;
+        this.label = label;
+    }
+
+    /** @internal */
+    public getCypher(env: CypherEnvironment): string {
+        const nodeId = this.node.getCypher(env);
+        const labelsStr = this.generateLabelExpressionStr(env);
+        return `${nodeId}${labelsStr}`;
+    }
+
+    private generateLabelExpressionStr(env: CypherEnvironment): string {
+        return addLabelToken(env.config.labelOperator, escapeLabel(this.label));
+    }
+}

--- a/src/references/NodeRef.ts
+++ b/src/references/NodeRef.ts
@@ -20,6 +20,7 @@
 import type { Expr } from "..";
 import { HasLabel } from "../expressions/HasLabel";
 import { LabelExpr } from "../expressions/labels/label-expressions";
+import { Label } from "./Label";
 import type { NamedReference } from "./Variable";
 import { Variable } from "./Variable";
 
@@ -54,6 +55,10 @@ export class NodeRef extends Variable {
         } else {
             return new HasLabel(this, label);
         }
+    }
+
+    public label(label: string): Label {
+        return new Label(this, label);
     }
 
     private parseLabels(labelsOption: NodeRefOptions["labels"]): string[] | LabelExpr {

--- a/src/utils/add-label-token.ts
+++ b/src/utils/add-label-token.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+/** Generates a string with all the labels. For example `:Movie&Film` */
 export function addLabelToken(andToken: ":" | "&", ...labels: string[]): string {
     const firstLabel = labels.shift();
     if (!firstLabel) return "";


### PR DESCRIPTION
Add support for labels in set and remove:

```js
const movie = new Cypher.Node();
const clause = new Cypher.Match(new Cypher.Pattern(movie)).set(movie.label("NewLabel"));
```

```cypher
MATCH (this0)
SET
    this0:NewLabel
```


Co-authored-by: @MacondoExpress
Co-authored-by: @angrykoala