### PR TITLE
Add support for offset

### DIFF
--- a/.changeset/gentle-papayas-nail.md
+++ b/.changeset/gentle-papayas-nail.md
@@ -1,0 +1,15 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Add support for `OFFSET` as an alias for `SKIP`:
+
+```js
+const matchQuery = new Cypher.Return(movieNode).orderBy([movieNode.property("age")]).offset(new Cypher.Param(10));
+```
+
+```cypher
+RETURN this0
+ORDER BY this0.age ASC
+OFFSET $param0
+```

--- a/src/clauses/Return.test.ts
+++ b/src/clauses/Return.test.ts
@@ -136,6 +136,27 @@ describe("CypherBuilder Return", () => {
             `);
         });
 
+        test("Return with order and offset param", () => {
+            const movieNode = new Cypher.Node();
+
+            const matchQuery = new Cypher.Return(movieNode)
+                .orderBy([movieNode.property("age")])
+                .offset(new Cypher.Param(10));
+
+            const queryResult = matchQuery.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+                "RETURN this0
+                ORDER BY this0.age ASC
+                OFFSET $param0"
+            `);
+
+            expect(queryResult.params).toMatchInlineSnapshot(`
+                {
+                  "param0": 10,
+                }
+            `);
+        });
+
         test("Return with order and limit", () => {
             const movieNode = new Cypher.Node();
 

--- a/src/clauses/mixins/sub-clauses/WithOrder.ts
+++ b/src/clauses/mixins/sub-clauses/WithOrder.ts
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
+import type { Expr } from "../../../types";
 import type { Order } from "../../sub-clauses/OrderBy";
 import { OrderBy } from "../../sub-clauses/OrderBy";
-import type { Expr } from "../../../types";
 import { Mixin } from "../Mixin";
 
 const DEFAULT_ORDER = "ASC";
@@ -50,6 +50,15 @@ export abstract class WithOrder extends Mixin {
     public skip(value: number | Expr): this {
         const orderByStatement = this.getOrCreateOrderBy();
         orderByStatement.skip(value);
+        return this;
+    }
+
+    /** Add a `OFFSET` subclause. An alias to `SKIP`
+     * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/skip/#offset-synonym)
+     */
+    public offset(value: number | Expr): this {
+        const orderByStatement = this.getOrCreateOrderBy();
+        orderByStatement.offset(value);
         return this;
     }
 

--- a/src/clauses/sub-clauses/OrderBy.ts
+++ b/src/clauses/sub-clauses/OrderBy.ts
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import type { CypherEnvironment } from "../../Environment";
 import { CypherASTNode } from "../../CypherASTNode";
+import type { CypherEnvironment } from "../../Environment";
 import type { Expr } from "../../types";
 import { compileCypherIfExists } from "../../utils/compile-cypher-if-exists";
 import { normalizeExpr } from "../../utils/normalize-variable";
@@ -40,6 +40,11 @@ export class OrderBy extends CypherASTNode {
     public skip(offset: number | Expr): void {
         const offsetVar = normalizeExpr(offset);
         this.skipClause = new Skip(offsetVar);
+    }
+
+    public offset(offset: number | Expr): void {
+        const offsetVar = normalizeExpr(offset);
+        this.skipClause = new Skip(offsetVar, true);
     }
 
     public limit(limit: number | Expr): void {
@@ -72,16 +77,19 @@ export class OrderBy extends CypherASTNode {
 }
 
 class Skip extends CypherASTNode {
-    private value: Expr;
+    private readonly value: Expr;
+    private readonly useOffset;
 
-    constructor(value: Expr) {
+    constructor(value: Expr, useOffset: boolean = false) {
         super();
         this.value = value;
+        this.useOffset = useOffset;
     }
 
     public getCypher(env: CypherEnvironment): string {
         const valueStr = this.value.getCypher(env);
-        return `SKIP ${valueStr}`;
+        const skipStr = this.useOffset ? "OFFSET" : "SKIP";
+        return `${skipStr} ${valueStr}`;
     }
 }
 


### PR DESCRIPTION
Add support for `OFFSET` alias for `SKIP`:

```js
const matchQuery = new Cypher.Return(movieNode).orderBy([movieNode.property("age")]).offset(new Cypher.Param(10));
```

```cypher
RETURN this0
ORDER BY this0.age ASC
OFFSET $param0
```