### PR TITLE
Add support for optional call

### DIFF
--- a/.changeset/fluffy-pants-scream.md
+++ b/.changeset/fluffy-pants-scream.md
@@ -1,0 +1,23 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for `OPTIONAL CALL`:
+
+```js
+new Cypher.OptionalCall(subquery);
+```
+
+Alternatively
+
+```js
+new Cypher.Call(subquery).optional();
+```
+
+To generate the following Cypher:
+
+```cypher
+OPTIONAL CALL {
+    // Subquery
+}
+```

--- a/docs/modules/ROOT/pages/subqueries/call.adoc
+++ b/docs/modules/ROOT/pages/subqueries/call.adoc
@@ -82,20 +82,16 @@ This can be achieved by using the `.importWith` method:
 
 [source, javascript]
 ----
-const dog = new Cypher.Node({ labels: ["Dog"] });
-const person = new Cypher.Node({ labels: ["Person"] });
+const dog = new Cypher.Node();
+const person = new Cypher.Node();
 
 const dogName = new Cypher.NamedVariable("dogName");
 
 const subquery = new Cypher.Match(
-    new Cypher.Pattern(person).related(new Cypher.Relationship({ type: "HAS_DOG" })).to(dog)
+    new Cypher.Pattern(person, {labels: ["Person"]}).related(new Cypher.Relationship({ type: "HAS_DOG" })).to(dog, {labels: ["Dog"]})
 ).return([dog.property("name"), dogName]);
 
-const match = new Cypher.Match(person);
-
-const callSubquery = new Cypher.Call(subquery).importWith(person).return(dogName);
-
-const clause = Cypher.utils.concat(match, subquery);
+const clause = new Cypher.Match(new Cypher.Pattern(person, {labels: ["Person"]})).call(subquery).importWith(person).return(dogName);
 ----
 
 [source, cypher]
@@ -117,22 +113,13 @@ A `CALL` subquery can be executed in separate transactions by using the `inTrans
 
 [source, javascript]
 ----
-const node = new Cypher.Node();
-
-const match = new Cypher.Match(node);
-const deleteSubquery = new Cypher.With(node).detachDelete(node);
-const callSubquery=new Cypher.Call(deleteSubquery).inTransactions();
-
-
-const query = Cypher.utils.concat(match, callSubquery);
+new Cypher.Match(node).call(deleteSubquery).inTransactions();
 ----
 
 [source, cypher]
 ----
-MATCH (this0)
 CALL {
-    WITH this0
-    DETACH DELETE this0
+    // Subquery
 } IN TRANSACTIONS
 ----
 
@@ -141,3 +128,28 @@ The method `inTransaction` accepts an object with the following options:
 * `ofRows`: A number to define the batch of rows. Translates to `IN TRANSACTIONS OF 10 ROWS`
 * `onError`: A behavior for error handling. This can be `continue`, `break` or `fail`. Translates to `ON ERROR CONTINUE`
 * `concurrentTransactions`: A number to execute concurrent transactions. Translates to `IN x CONCURRENT TRANSACTIONS`
+
+== Optional Call
+
+A `CALL` subquery can be converted to an `OPTIONAL CALL` by using the `.optional` method:
+
+[source, javascript]
+----
+new Cypher.Call(deleteSubquery).optional();
+----
+
+Alternatively, the clause `OptionalCall` can be used to create an `OPTIONAL CALL` directly:
+
+[source, javascript]
+----
+new Cypher.OptionalCall(deleteSubquery);
+----
+
+Both will generate the Cypher:
+
+[source, cypher]
+----
+OPTIONAL CALL {
+    // Subquery
+}
+----

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -18,7 +18,7 @@
  */
 
 // Clauses
-export { Call } from "./clauses/Call";
+export { Call, OptionalCall } from "./clauses/Call";
 export { Create } from "./clauses/Create";
 export { Finish } from "./clauses/Finish";
 export { Foreach } from "./clauses/Foreach";

--- a/src/clauses/Call.test.ts
+++ b/src/clauses/Call.test.ts
@@ -640,5 +640,53 @@ RETURN this0"
 `);
             expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });
+
+        describe("Optional Call", () => {
+            test("Wraps query inside Call with optional method", () => {
+                const idParam = new Cypher.Param("my-id");
+                const movieNode = new Cypher.Node();
+
+                const createQuery = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+                    .set([movieNode.property("id"), idParam])
+                    .return(movieNode);
+                const queryResult = new Cypher.Call(createQuery).optional().build();
+                expect(queryResult.cypher).toMatchInlineSnapshot(`
+"OPTIONAL CALL {
+    CREATE (this0:Movie)
+    SET
+        this0.id = $param0
+    RETURN this0
+}"
+`);
+                expect(queryResult.params).toMatchInlineSnapshot(`
+                    {
+                      "param0": "my-id",
+                    }
+                `);
+            });
+
+            test("Wraps query inside OptionalCall", () => {
+                const idParam = new Cypher.Param("my-id");
+                const movieNode = new Cypher.Node();
+
+                const createQuery = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+                    .set([movieNode.property("id"), idParam])
+                    .return(movieNode);
+                const queryResult = new Cypher.OptionalCall(createQuery).build();
+                expect(queryResult.cypher).toMatchInlineSnapshot(`
+"OPTIONAL CALL {
+    CREATE (this0:Movie)
+    SET
+        this0.id = $param0
+    RETURN this0
+}"
+`);
+                expect(queryResult.params).toMatchInlineSnapshot(`
+                    {
+                      "param0": "my-id",
+                    }
+                `);
+            });
+        });
     });
 });

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -724,7 +724,7 @@ RETURN var1"
     });
 
     describe("Match.call", () => {
-        test("Match.Call with variable scope", () => {
+        test("Match.call with variable scope", () => {
             const movieNode = new Cypher.Node();
             const actorNode = new Cypher.Node();
 
@@ -738,6 +738,30 @@ RETURN var1"
 "MATCH (this0:Movie)
 MATCH (this1:Actor)
 CALL (this0, this1) {
+    CREATE (this0)-[this2]->(this1)
+}
+RETURN this0"
+`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("Match.optionalCall with variable scope", () => {
+            const movieNode = new Cypher.Node();
+            const actorNode = new Cypher.Node();
+
+            const match = new Cypher.Match(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+                .match(new Cypher.Pattern(actorNode, { labels: ["Actor"] }))
+                .optionalCall(new Cypher.Create(new Cypher.Pattern(movieNode).related().to(actorNode)), [
+                    movieNode,
+                    actorNode,
+                ])
+                .return(movieNode);
+
+            const { cypher, params } = match.build();
+            expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+MATCH (this1:Actor)
+OPTIONAL CALL (this0, this1) {
     CREATE (this0)-[this2]->(this1)
 }
 RETURN this0"

--- a/src/clauses/mixins/clauses/WithCall.ts
+++ b/src/clauses/mixins/clauses/WithCall.ts
@@ -18,7 +18,7 @@
  */
 
 import type { Clause, Variable } from "../../..";
-import { Call } from "../../..";
+import { Call, OptionalCall } from "../../..";
 import { MixinClause } from "../Mixin";
 
 export abstract class WithCall extends MixinClause {
@@ -27,6 +27,15 @@ export abstract class WithCall extends MixinClause {
      */
     public call(subquery: Clause, variableScope?: Variable[] | "*"): Call {
         const callClause = new Call(subquery, variableScope);
+        this.addNextClause(callClause);
+
+        return callClause;
+    }
+
+    /** Add a {@link OptionalCall} clause
+     */
+    public optionalCall(subquery: Clause, variableScope?: Variable[] | "*"): Call {
+        const callClause = new OptionalCall(subquery, variableScope);
         this.addNextClause(callClause);
 
         return callClause;


### PR DESCRIPTION

Add support for `OPTIONAL CALL`:

```js
new Cypher.OptionalCall(subquery);
```

Alternatively

```js
new Cypher.Call(subquery).optional();
```

To generate the following Cypher:

```cypher
OPTIONAL CALL {
    // Subquery
}
```