### PR TITLE
Add order by chaining

### DIFF
--- a/.changeset/red-elephants-decide.md
+++ b/.changeset/red-elephants-decide.md
@@ -1,0 +1,12 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Add support for order by, skip and limit chaining after the following clauses:
+
+-   Call
+-   Merge
+-   Create
+-   Match
+-   Unwind
+-   Procedures

--- a/src/clauses/Call.test.ts
+++ b/src/clauses/Call.test.ts
@@ -689,4 +689,29 @@ RETURN this0"
             });
         });
     });
+
+    test("Call followed by Order By", () => {
+        const idParam = new Cypher.Param("my-id");
+        const movieNode = new Cypher.Node();
+
+        const createQuery = new Cypher.Create(new Cypher.Pattern(movieNode, { labels: ["Movie"] }))
+            .set([movieNode.property("id"), idParam])
+            .return(movieNode);
+        const queryResult = new Cypher.Call(createQuery).orderBy(movieNode).skip(10).build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"CALL {
+    CREATE (this0:Movie)
+    SET
+        this0.id = $param0
+    RETURN this0
+}
+ORDER BY this0 ASC
+SKIP 10"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": "my-id",
+            }
+        `);
+    });
 });

--- a/src/clauses/Call.ts
+++ b/src/clauses/Call.ts
@@ -31,6 +31,7 @@ import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithUnwind } from "./mixins/clauses/WithUnwind";
 import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
+import { WithOrder } from "./mixins/sub-clauses/WithOrder";
 import { WithRemove } from "./mixins/sub-clauses/WithRemove";
 import { WithSet } from "./mixins/sub-clauses/WithSet";
 import { ImportWith } from "./sub-clauses/ImportWith";
@@ -46,7 +47,8 @@ export interface Call
         WithDelete,
         WithMatch,
         WithCreate,
-        WithMerge {}
+        WithMerge,
+        WithOrder {}
 
 type InTransactionConfig = {
     ofRows?: number;
@@ -58,7 +60,7 @@ type InTransactionConfig = {
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/call-subquery/)
  * @category Clauses
  */
-@mixin(WithReturn, WithWith, WithUnwind, WithRemove, WithDelete, WithSet, WithMatch, WithCreate, WithMerge)
+@mixin(WithReturn, WithWith, WithUnwind, WithRemove, WithDelete, WithSet, WithMatch, WithCreate, WithMerge, WithOrder)
 export class Call extends Clause {
     private subquery: CypherASTNode;
     private _importWith?: ImportWith;
@@ -133,6 +135,7 @@ export class Call extends Clause {
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
         const deleteCypher = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const setCypher = compileCypherIfExists(this.setSubClause, env, { prefix: "\n" });
+        const orderByCypher = compileCypherIfExists(this.orderByStatement, env, { prefix: "\n" });
         const inTransactionCypher = this.generateInTransactionStr();
 
         const inCallBlock = `${importWithCypher}${subQueryStr}`;
@@ -141,7 +144,7 @@ export class Call extends Clause {
 
         const optionalStr = this._optional ? "OPTIONAL " : "";
 
-        return `${optionalStr}CALL${variableScopeStr} {\n${padBlock(inCallBlock)}\n}${inTransactionCypher}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;
+        return `${optionalStr}CALL${variableScopeStr} {\n${padBlock(inCallBlock)}\n}${inTransactionCypher}${setCypher}${removeCypher}${deleteCypher}${orderByCypher}${nextClause}`;
     }
 
     private getSubqueryCypher(env: CypherEnvironment, importWithCypher: string | undefined): string {

--- a/src/clauses/Create.test.ts
+++ b/src/clauses/Create.test.ts
@@ -399,4 +399,48 @@ RETURN this0"
 }
 `);
     });
+
+    test("Create with order by", () => {
+        const idParam = new Cypher.Param("my-id");
+        const movieNode = new Cypher.Node();
+
+        const createQuery = new Cypher.Create(
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                    id: idParam,
+                },
+            })
+        )
+            .set(
+                [movieNode.property("title"), new Cypher.Param("The Matrix")],
+                [movieNode.property("runtime"), new Cypher.Param(120)]
+            )
+            .orderBy([movieNode.property("title"), "DESC"])
+            .skip(10)
+            .limit(1)
+            .return(movieNode);
+
+        const queryResult = createQuery.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"CREATE (this0:Movie { test: $param0, id: $param1 })
+SET
+    this0.title = $param2,
+    this0.runtime = $param3
+ORDER BY this0.title DESC
+SKIP 10
+LIMIT 1
+RETURN this0"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": "test-value",
+              "param1": "my-id",
+              "param2": "The Matrix",
+              "param3": 120,
+            }
+        `);
+    });
 });

--- a/src/clauses/Create.ts
+++ b/src/clauses/Create.ts
@@ -28,6 +28,7 @@ import { WithMerge } from "./mixins/clauses/WithMerge";
 import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
+import { WithOrder } from "./mixins/sub-clauses/WithOrder";
 import { WithRemove } from "./mixins/sub-clauses/WithRemove";
 import { WithSet } from "./mixins/sub-clauses/WithSet";
 import { SetClause } from "./sub-clauses/Set";
@@ -41,13 +42,14 @@ export interface Create
         WithDelete,
         WithRemove,
         WithMerge,
-        WithFinish {}
+        WithFinish,
+        WithOrder {}
 
 /**
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/create/)
  * @category Clauses
  */
-@mixin(WithReturn, WithSet, WithPathAssign, WithWith, WithDelete, WithRemove, WithMerge, WithFinish)
+@mixin(WithReturn, WithSet, WithPathAssign, WithWith, WithDelete, WithRemove, WithMerge, WithFinish, WithOrder)
 export class Create extends Clause {
     private pattern: Pattern;
 
@@ -92,8 +94,9 @@ export class Create extends Clause {
         const setCypher = compileCypherIfExists(this.setSubClause, env, { prefix: "\n" });
         const deleteStr = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
+        const orderByCypher = compileCypherIfExists(this.orderByStatement, env, { prefix: "\n" });
 
         const nextClause = this.compileNextClause(env);
-        return `CREATE ${pathCypher}${patternCypher}${setCypher}${removeCypher}${deleteStr}${nextClause}`;
+        return `CREATE ${pathCypher}${patternCypher}${setCypher}${removeCypher}${deleteStr}${orderByCypher}${nextClause}`;
     }
 }

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -533,6 +533,47 @@ RETURN this0"
         });
     });
 
+    test("Match with order by", () => {
+        const idParam = new Cypher.Param("my-id");
+        const nameParam = new Cypher.Param("my-name");
+        const ageParam = new Cypher.Param(5);
+
+        const movieNode = new Cypher.Node();
+
+        const matchQuery = new Cypher.Match(
+            new Cypher.Pattern(movieNode, {
+                labels: ["Movie"],
+                properties: {
+                    test: new Cypher.Param("test-value"),
+                },
+            })
+        )
+            .orderBy([movieNode.property("title"), "DESC"])
+            .skip(10)
+            .limit(2)
+            .where(movieNode, { id: idParam, name: nameParam, age: ageParam })
+            .return(movieNode);
+
+        const queryResult = matchQuery.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie { test: $param0 })
+WHERE ((this0.id = $param1 AND this0.name = $param2) AND this0.age = $param3)
+ORDER BY this0.title DESC
+SKIP 10
+LIMIT 2
+RETURN this0"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+                {
+                  "param0": "test-value",
+                  "param1": "my-id",
+                  "param2": "my-name",
+                  "param3": 5,
+                }
+            `);
+    });
+
     describe("With delete", () => {
         test("Match and delete with return", () => {
             const idParam = new Cypher.Param("my-id");

--- a/src/clauses/Match.ts
+++ b/src/clauses/Match.ts
@@ -33,6 +33,7 @@ import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithUnwind } from "./mixins/clauses/WithUnwind";
 import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
+import { WithOrder } from "./mixins/sub-clauses/WithOrder";
 import { WithRemove } from "./mixins/sub-clauses/WithRemove";
 import { WithSet } from "./mixins/sub-clauses/WithSet";
 import { WithWhere } from "./mixins/sub-clauses/WithWhere";
@@ -51,7 +52,8 @@ export interface Match
         WithMerge,
         WithFinish,
         WithCallProcedure,
-        WithCall {}
+        WithCall,
+        WithOrder {}
 
 type ShortestStatement = {
     type: "ALL SHORTEST" | "SHORTEST" | "ANY" | "SHORTEST_GROUPS";
@@ -75,7 +77,8 @@ type ShortestStatement = {
     WithMerge,
     WithFinish,
     WithCallProcedure,
-    WithCall
+    WithCall,
+    WithOrder
 )
 export class Match extends Clause {
     private pattern: Pattern | QuantifiedPath;
@@ -183,10 +186,11 @@ export class Match extends Clause {
         const setCypher = compileCypherIfExists(this.setSubClause, env, { prefix: "\n" });
         const deleteCypher = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
+        const orderByCypher = compileCypherIfExists(this.orderByStatement, env, { prefix: "\n" });
         const optionalMatch = this._optional ? "OPTIONAL " : "";
         const shortestStatement = this.getShortestStatement();
 
-        return `${optionalMatch}MATCH ${shortestStatement}${pathAssignStr}${patternCypher}${whereCypher}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;
+        return `${optionalMatch}MATCH ${shortestStatement}${pathAssignStr}${patternCypher}${whereCypher}${setCypher}${removeCypher}${deleteCypher}${orderByCypher}${nextClause}`;
     }
 
     private getShortestStatement(): string {

--- a/src/clauses/Merge.test.ts
+++ b/src/clauses/Merge.test.ts
@@ -320,4 +320,29 @@ FINISH"
             }
         `);
     });
+
+    test("Merge node with order", () => {
+        const node = new Cypher.Node();
+
+        const query = new Cypher.Merge(
+            new Cypher.Pattern(node, {
+                labels: ["MyLabel"],
+            })
+        )
+            .onCreateSet([node.property("age"), new Cypher.Param(23)])
+            .orderBy([node.property("age"), "ASC"]);
+
+        const queryResult = query.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MERGE (this0:MyLabel)
+ON CREATE SET
+    this0.age = $param0
+ORDER BY this0.age ASC"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": 23,
+            }
+        `);
+    });
 });

--- a/src/clauses/Merge.ts
+++ b/src/clauses/Merge.ts
@@ -28,6 +28,7 @@ import { WithFinish } from "./mixins/clauses/WithFinish";
 import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
+import { WithOrder } from "./mixins/sub-clauses/WithOrder";
 import { WithRemove } from "./mixins/sub-clauses/WithRemove";
 import { WithSet } from "./mixins/sub-clauses/WithSet";
 import type { OnCreateParam } from "./sub-clauses/OnCreate";
@@ -43,13 +44,14 @@ export interface Merge
         WithRemove,
         WithWith,
         WithCreate,
-        WithFinish {}
+        WithFinish,
+        WithOrder {}
 
 /**
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/merge/)
  * @category Clauses
  */
-@mixin(WithReturn, WithSet, WithPathAssign, WithDelete, WithRemove, WithWith, WithCreate, WithFinish)
+@mixin(WithReturn, WithSet, WithPathAssign, WithDelete, WithRemove, WithWith, WithCreate, WithFinish, WithOrder)
 export class Merge extends Clause {
     private pattern: Pattern;
     private onCreateClause: OnCreate;
@@ -119,8 +121,9 @@ export class Merge extends Clause {
         const onMatchCypher = compileCypherIfExists(this.onMatchClause, env, { prefix: "\n" });
         const deleteCypher = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
+        const orderCypher = compileCypherIfExists(this.orderByStatement, env, { prefix: "\n" });
         const nextClause = this.compileNextClause(env);
 
-        return `${mergeStr}${onMatchCypher}${onCreateCypher}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;
+        return `${mergeStr}${onMatchCypher}${onCreateCypher}${setCypher}${removeCypher}${deleteCypher}${orderCypher}${nextClause}`;
     }
 }

--- a/src/clauses/Unwind.test.ts
+++ b/src/clauses/Unwind.test.ts
@@ -20,7 +20,7 @@
 import * as Cypher from "../Cypher";
 
 describe("CypherBuilder Unwind", () => {
-    test("Unwind Movies", () => {
+    test("Unwind movies", () => {
         const matrix = new Cypher.Map({ title: new Cypher.Literal("Matrix") });
         const matrix2 = new Cypher.Map({ title: new Cypher.Literal("Matrix 2") });
         const moviesList = new Cypher.List([matrix, matrix2]);
@@ -100,5 +100,21 @@ UNWIND var1 AS var2"
         expect(() => {
             unwindQuery.unwind([variable, new Cypher.Variable()]);
         }).toThrow("Invalid Unwind statement");
+    });
+
+    test("Unwind movies with order", () => {
+        const matrix = new Cypher.Map({ title: new Cypher.Literal("Matrix") });
+        const matrix2 = new Cypher.Map({ title: new Cypher.Literal("Matrix 2") });
+        const moviesList = new Cypher.List([matrix, matrix2]);
+
+        const batch = new Cypher.Variable();
+        const unwindQuery = new Cypher.Unwind([moviesList, batch]).orderBy([batch.property("title", "DESC")]).limit(10);
+        const queryResult = unwindQuery.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"UNWIND [{ title: \\"Matrix\\" }, { title: \\"Matrix 2\\" }] AS var0
+ORDER BY var0.title.DESC ASC
+LIMIT 10"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
 });

--- a/src/clauses/Unwind.ts
+++ b/src/clauses/Unwind.ts
@@ -26,6 +26,7 @@ import { WithMerge } from "./mixins/clauses/WithMerge";
 import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
+import { WithOrder } from "./mixins/sub-clauses/WithOrder";
 import { WithRemove } from "./mixins/sub-clauses/WithRemove";
 import { WithSet } from "./mixins/sub-clauses/WithSet";
 import type { ProjectionColumn } from "./sub-clauses/Projection";
@@ -40,13 +41,14 @@ export interface Unwind
         WithRemove,
         WithSet,
         WithCreate,
-        WithMerge {}
+        WithMerge,
+        WithOrder {}
 
 /**
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/unwind/)
  * @category Clauses
  */
-@mixin(WithWith, WithDelete, WithMatch, WithReturn, WithRemove, WithSet, WithCreate, WithMerge)
+@mixin(WithWith, WithDelete, WithMatch, WithReturn, WithRemove, WithSet, WithCreate, WithMerge, WithOrder)
 export class Unwind extends Clause {
     private projection: Projection;
 
@@ -81,10 +83,11 @@ export class Unwind extends Clause {
         const deleteCypher = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const setCypher = compileCypherIfExists(this.setSubClause, env, { prefix: "\n" });
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
+        const orderCypher = compileCypherIfExists(this.orderByStatement, env, { prefix: "\n" });
 
         const nextClause = this.compileNextClause(env);
 
-        return `UNWIND ${projectionStr}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;
+        return `UNWIND ${projectionStr}${setCypher}${removeCypher}${deleteCypher}${orderCypher}${nextClause}`;
     }
 
     private addColumnsToUnwindClause(...columns: Array<"*" | ProjectionColumn>): Unwind {

--- a/src/procedures/CypherProcedure.test.ts
+++ b/src/procedures/CypherProcedure.test.ts
@@ -207,5 +207,22 @@ CREATE (this0)"
 `);
             expect(params).toMatchInlineSnapshot(`{}`);
         });
+
+        it("Procedure with Order by", () => {
+            const testVar = new Cypher.NamedVariable("test");
+            const procedure = new Cypher.Procedure("custom-procedure").yield("test").orderBy(testVar).skip(1).limit(10);
+
+            procedure.create(new Cypher.Pattern(new Cypher.Node()));
+            const { cypher, params } = procedure.build();
+
+            expect(cypher).toMatchInlineSnapshot(`
+"CALL custom-procedure() YIELD test
+ORDER BY test ASC
+SKIP 1
+LIMIT 10
+CREATE (this0)"
+`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
     });
 });

--- a/src/procedures/Yield.ts
+++ b/src/procedures/Yield.ts
@@ -26,6 +26,7 @@ import { WithReturn } from "../clauses/mixins/clauses/WithReturn";
 import { WithUnwind } from "../clauses/mixins/clauses/WithUnwind";
 import { WithWith } from "../clauses/mixins/clauses/WithWith";
 import { WithDelete } from "../clauses/mixins/sub-clauses/WithDelete";
+import { WithOrder } from "../clauses/mixins/sub-clauses/WithOrder";
 import { WithRemove } from "../clauses/mixins/sub-clauses/WithRemove";
 import { WithSet } from "../clauses/mixins/sub-clauses/WithSet";
 import { WithWhere } from "../clauses/mixins/sub-clauses/WithWhere";
@@ -51,13 +52,26 @@ export interface Yield
         WithMerge,
         WithCreate,
         WithRemove,
-        WithSet {}
+        WithSet,
+        WithOrder {}
 
 /** Yield statement after a Procedure CALL
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/call/#call-call-a-procedure-call-yield-star)
  * @group Procedures
  */
-@mixin(WithReturn, WithWhere, WithWith, WithMatch, WithUnwind, WithDelete, WithMerge, WithCreate, WithRemove, WithSet)
+@mixin(
+    WithReturn,
+    WithWhere,
+    WithWith,
+    WithMatch,
+    WithUnwind,
+    WithDelete,
+    WithMerge,
+    WithCreate,
+    WithRemove,
+    WithSet,
+    WithOrder
+)
 export class Yield<T extends string = string> extends Clause {
     private projection: YieldProjection;
 
@@ -80,13 +94,14 @@ export class Yield<T extends string = string> extends Clause {
         const deleteCypher = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const removeCypher = compileCypherIfExists(this.removeClause, env, { prefix: "\n" });
         const setCypher = compileCypherIfExists(this.setSubClause, env, { prefix: "\n" });
+        const orderByCypher = compileCypherIfExists(this.orderByStatement, env, { prefix: "\n" });
 
         const whereStr = compileCypherIfExists(this.whereSubClause, env, {
             prefix: "\n",
         });
 
         const nextClause = this.compileNextClause(env);
-        return `YIELD ${yieldProjectionStr}${whereStr}${setCypher}${removeCypher}${deleteCypher}${nextClause}`;
+        return `YIELD ${yieldProjectionStr}${whereStr}${setCypher}${removeCypher}${deleteCypher}${orderByCypher}${nextClause}`;
     }
 }
 

--- a/tests/clause-chaining.test.ts
+++ b/tests/clause-chaining.test.ts
@@ -39,6 +39,10 @@ describe("Clause chaining", () => {
             "merge",
             "create",
             "assignToPath",
+            "orderBy",
+            "limit",
+            "skip",
+            "offset",
         ] as const)("Match.%s", (value) => {
             expect(clause[value]).toBeFunction();
         });
@@ -57,6 +61,10 @@ describe("Clause chaining", () => {
             "merge",
             "create",
             "assignToPath",
+            "orderBy",
+            "limit",
+            "skip",
+            "offset",
         ] as const)("Create.%s", (value) => {
             expect(clause[value]).toBeFunction();
         });
@@ -76,8 +84,11 @@ describe("Clause chaining", () => {
             "match",
             "optionalMatch",
             "merge",
-
             "create",
+            "orderBy",
+            "limit",
+            "skip",
+            "offset",
         ] as const)("Call.%s", (value) => {
             expect(clause[value]).toBeFunction();
         });
@@ -111,9 +122,12 @@ describe("Clause chaining", () => {
             "detachDelete",
             "with",
             "merge",
-
             "create",
             "assignToPath",
+            "orderBy",
+            "limit",
+            "skip",
+            "offset",
         ] as const)("Merge.%s", (value) => {
             expect(clause[value]).toBeFunction();
         });
@@ -122,7 +136,7 @@ describe("Clause chaining", () => {
     describe("Return", () => {
         const clause = new Cypher.Return();
 
-        it.each(["orderBy", "limit", "skip"] as const)("Return.%s", (value) => {
+        it.each(["orderBy", "limit", "skip", "offset"] as const)("Return.%s", (value) => {
             expect(clause[value]).toBeFunction();
         });
     });
@@ -142,6 +156,10 @@ describe("Clause chaining", () => {
             "optionalMatch",
             "merge",
             "create",
+            "orderBy",
+            "limit",
+            "skip",
+            "offset",
         ] as const)("Unwind.%s", (value) => {
             expect(clause[value]).toBeFunction();
         });
@@ -203,6 +221,9 @@ describe("Clause chaining", () => {
             "create",
             "remove",
             "set",
+            "orderBy",
+            "skip",
+            "limit",
         ] as const)("With.%s", (value) => {
             expect(clause[value]).toBeFunction();
         });
@@ -210,7 +231,7 @@ describe("Clause chaining", () => {
 
     describe("Invalid Chaining", () => {
         test("Multiple top-level clauses should fail", () => {
-            const match = new Cypher.Match(new Cypher.Node());
+            const match = new Cypher.Match(new Cypher.Pattern(new Cypher.Node()));
             match.return("*");
             expect(() => {
                 match.return("*");


### PR DESCRIPTION
Add support for order by, skip and limit chaining after the following clauses:

-   Call
-   Merge
-   Create
-   Match
-   Unwind
-   Procedures

These are valid as of Cypher 5.24