### PR TITLE
Update nodejs version in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: lts/*
       - run: npm install
       - run: npm run lint
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: lts/*
       - run: npm install
 
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, lts/*, latest]
+        node-version: [16.x, lts/*, 22.x]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Due to an issue between `23.0` and `jest`, for now we will pin testing to 22 as the latest version

Probably related to https://github.com/jestjs/jest/issues/15348