### PR TITLE
Deprecate pattern comprehension node

### DIFF
--- a/.changeset/nervous-boats-deny.md
+++ b/.changeset/nervous-boats-deny.md
@@ -1,0 +1,10 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecate using a `Node` as a constructor of `Cypher.PatternComprehension`:
+
+```js
+const node = new Cypher.Node();
+const comprehension = new Cypher.PatternComprehension(node);
+```

--- a/src/expressions/list/PatternComprehension.ts
+++ b/src/expressions/list/PatternComprehension.ts
@@ -39,6 +39,9 @@ export class PatternComprehension extends CypherASTNode {
     private mapExpr: Expr | undefined;
 
     // NOTE: mapExpr parameter is deprecated in favour of `.map`
+    constructor(pattern: Pattern, mapExpr?: Expr);
+    /** @deprecated Use {@link Pattern} instead */
+    constructor(pattern: NodeRef, mapExpr?: Expr);
     constructor(pattern: Pattern | NodeRef, mapExpr?: Expr) {
         super();
         if (pattern instanceof Pattern) {

--- a/src/expressions/list/PatternComprehension.ts
+++ b/src/expressions/list/PatternComprehension.ts
@@ -38,7 +38,8 @@ export class PatternComprehension extends CypherASTNode {
     private pattern: Pattern;
     private mapExpr: Expr | undefined;
 
-    // NOTE: mapExpr parameter is deprecated in favour of `.map`
+    constructor(pattern: Pattern);
+    /** @deprecated Use `.map` instead of a second argument */
     constructor(pattern: Pattern, mapExpr?: Expr);
     /** @deprecated Use {@link Pattern} instead */
     constructor(pattern: NodeRef, mapExpr?: Expr);


### PR DESCRIPTION
These deprecations were not properly marked in tsdoc

Changes in 2.x branch already done