### PR TITLE
Revert update of node version

### DIFF
--- a/.changeset/gorgeous-badgers-tie.md
+++ b/.changeset/gorgeous-badgers-tie.md
@@ -1,5 +1,0 @@
----
-"@neo4j/cypher-builder": major
----
-
-Update node version to 18

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, lts/*, latest]
+        node-version: [16.x, lts/*, latest]
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=18.0.0"
+        "node": ">=16.0.0"
     },
     "scripts": {
         "test": "jest",


### PR DESCRIPTION
Cypher Builder 2 will retain support for Node 16