### PR TITLE
Removes default node in nested node

### DIFF
--- a/src/clauses/Call.test.ts
+++ b/src/clauses/Call.test.ts
@@ -578,7 +578,7 @@ CALL {
 "MATCH (this0:Movie)
 MATCH (this1:Actor)
 CALL (this0, this1) {
-    CREATE (this0)-[this2]->(this1)
+    CREATE (this0)-[]->(this1)
 }
 RETURN this0"
 `);
@@ -610,7 +610,7 @@ RETURN this0"
             const queryResult = clause.build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`
 "CALL () {
-    CREATE (this0)-[this1]->(this2)
+    CREATE (this0)-[]->(this1)
 }
 RETURN this0"
 `);
@@ -634,7 +634,7 @@ RETURN this0"
 "MATCH (this0:Movie)
 MATCH (this1:Actor)
 CALL (*) {
-    CREATE (this0)-[this2]->(this1)
+    CREATE (this0)-[]->(this1)
 }
 RETURN this0"
 `);

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -779,7 +779,7 @@ RETURN var1"
 "MATCH (this0:Movie)
 MATCH (this1:Actor)
 CALL (this0, this1) {
-    CREATE (this0)-[this2]->(this1)
+    CREATE (this0)-[]->(this1)
 }
 RETURN this0"
 `);
@@ -803,7 +803,7 @@ RETURN this0"
 "MATCH (this0:Movie)
 MATCH (this1:Actor)
 OPTIONAL CALL (this0, this1) {
-    CREATE (this0)-[this2]->(this1)
+    CREATE (this0)-[]->(this1)
 }
 RETURN this0"
 `);
@@ -832,7 +832,7 @@ RETURN this0"
 
             const queryResult = matchQuery.build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MATCH SHORTEST 2 (this0:Movie { test: $param0 })-[this1]->(this2:Person)
+"MATCH SHORTEST 2 (this0:Movie { test: $param0 })-[]->(this1:Person)
 RETURN this0"
 `);
         });
@@ -857,7 +857,7 @@ RETURN this0"
 
             const queryResult = matchQuery.build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MATCH SHORTEST 2 GROUPS (this0:Movie { test: $param0 })-[this1]->(this2:Person)
+"MATCH SHORTEST 2 GROUPS (this0:Movie { test: $param0 })-[]->(this1:Person)
 RETURN this0"
 `);
         });
@@ -882,7 +882,7 @@ RETURN this0"
 
             const queryResult = matchQuery.build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MATCH ALL SHORTEST (this0:Movie { test: $param0 })-[this1]->(this2:Person)
+"MATCH ALL SHORTEST (this0:Movie { test: $param0 })-[]->(this1:Person)
 RETURN this0"
 `);
         });
@@ -907,7 +907,7 @@ RETURN this0"
 
             const queryResult = matchQuery.build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MATCH ANY (this0:Movie { test: $param0 })-[this1]->(this2:Person)
+"MATCH ANY (this0:Movie { test: $param0 })-[]->(this1:Person)
 RETURN this0"
 `);
 

--- a/src/clauses/With.test.ts
+++ b/src/clauses/With.test.ts
@@ -310,9 +310,9 @@ CALL apoc.util.validate(true, \\"message\\", [0])"
             expect(cypher).toMatchInlineSnapshot(`
 "WITH this0
 CALL (this0) {
-    CREATE (this0)-[this1]->(this2)
+    CREATE (this0)-[]->(this1)
 }
-RETURN this2"
+RETURN this1"
 `);
             expect(params).toMatchInlineSnapshot(`{}`);
         });

--- a/src/clauses/sub-clauses/Remove.test.ts
+++ b/src/clauses/sub-clauses/Remove.test.ts
@@ -43,8 +43,8 @@ REMOVE this0:NewLabel"
 
         const queryResult = clause.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MATCH (this0)-[this1]->(this2)
-REMOVE this0:NewLabel,this2:\`Another Label\`"
+"MATCH (this0)-[]->(this1)
+REMOVE this0:NewLabel,this1:\`Another Label\`"
 `);
 
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);

--- a/src/clauses/sub-clauses/Set.test.ts
+++ b/src/clauses/sub-clauses/Set.test.ts
@@ -62,10 +62,10 @@ SET
 
         const queryResult = clause.build();
         expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MATCH (this0)-[this1]->(this2)
+"MATCH (this0)-[]->(this1)
 SET
     this0:NewLabel,
-    this2:\`Another Label\`"
+    this1:\`Another Label\`"
 `);
 
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);

--- a/src/expressions/HasLabel.test.ts
+++ b/src/expressions/HasLabel.test.ts
@@ -105,7 +105,7 @@ WHERE this0:(Movie|Film)"
             const queryResult = new TestClause(query).build();
 
             expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MATCH (this0:Movie)-[this1]->(this2)
+"MATCH (this0:Movie)-[this1]->()
 WHERE this1:ACTED_IN"
 `);
 
@@ -122,7 +122,7 @@ WHERE this1:ACTED_IN"
             const queryResult = new TestClause(query).build();
 
             expect(queryResult.cypher).toMatchInlineSnapshot(`
-"MATCH (this0:Movie)-[this1:ACTED_IN]->(this2)
+"MATCH (this0:Movie)-[this1:ACTED_IN]->()
 WHERE this1:(ACTED_IN|STARRED_IN)"
 `);
 

--- a/src/expressions/functions/scalar.test.ts
+++ b/src/expressions/functions/scalar.test.ts
@@ -94,7 +94,7 @@ describe("Scalar Functions", () => {
         const cypherFunction = Cypher.size(patternComprehension);
         const queryResult = new TestClause(cypherFunction).build();
 
-        expect(queryResult.cypher).toMatchInlineSnapshot(`"size([(this1)-[this2]->(this3) | var0])"`);
+        expect(queryResult.cypher).toMatchInlineSnapshot(`"size([(this1)-[this2]->() | var0])"`);
     });
 
     test("size() applied to string", () => {
@@ -109,6 +109,6 @@ describe("Scalar Functions", () => {
         const cypherFunction = Cypher.size(pattern);
         const queryResult = new TestClause(cypherFunction).build();
 
-        expect(queryResult.cypher).toMatchInlineSnapshot(`"size((this0)-[this1]->(this2))"`);
+        expect(queryResult.cypher).toMatchInlineSnapshot(`"size((this0)-[this1]->())"`);
     });
 });

--- a/src/expressions/functions/scalar.test.ts
+++ b/src/expressions/functions/scalar.test.ts
@@ -94,7 +94,7 @@ describe("Scalar Functions", () => {
         const cypherFunction = Cypher.size(patternComprehension);
         const queryResult = new TestClause(cypherFunction).build();
 
-        expect(queryResult.cypher).toMatchInlineSnapshot(`"size([(this1)-[this2]->() | var0])"`);
+        expect(queryResult.cypher).toMatchInlineSnapshot(`"size([(this1)-[]->() | var0])"`);
     });
 
     test("size() applied to string", () => {
@@ -109,6 +109,6 @@ describe("Scalar Functions", () => {
         const cypherFunction = Cypher.size(pattern);
         const queryResult = new TestClause(cypherFunction).build();
 
-        expect(queryResult.cypher).toMatchInlineSnapshot(`"size((this0)-[this1]->())"`);
+        expect(queryResult.cypher).toMatchInlineSnapshot(`"size((this0)-[]->())"`);
     });
 });

--- a/src/pattern/PartialPattern.ts
+++ b/src/pattern/PartialPattern.ts
@@ -21,7 +21,6 @@ import type { CypherEnvironment } from "../Environment";
 import { WithWhere } from "../clauses/mixins/sub-clauses/WithWhere";
 import { mixin } from "../clauses/utils/mixin";
 import type { LabelExpr } from "../expressions/labels/label-expressions";
-import { NodeRef } from "../references/NodeRef";
 import type { Variable } from "../references/Variable";
 import type { Expr } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
@@ -65,7 +64,6 @@ export class PartialPattern extends PatternElement {
     public to(node: Variable | undefined, options?: NodePattern): Pattern;
     public to(nodeConfig?: NodePattern): Pattern;
     public to(node?: Variable | NodePattern, options?: NodePattern): Pattern {
-        if (!node) node = new NodeRef();
         return new NestedPattern(node, options, this);
     }
 

--- a/src/pattern/Pattern.test.ts
+++ b/src/pattern/Pattern.test.ts
@@ -168,7 +168,7 @@ describe("Patterns", () => {
         });
 
         test("Simple relationship Pattern without variables", () => {
-            const query = new TestClause(new Cypher.Pattern({}).related({}).to({}));
+            const query = new TestClause(new Cypher.Pattern().related().to());
             const queryResult = query.build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`"()-[]->()"`);
 

--- a/src/pattern/Pattern.test.ts
+++ b/src/pattern/Pattern.test.ts
@@ -274,7 +274,7 @@ describe("Patterns", () => {
 
             const query = new TestClause(new Cypher.Pattern(a).related(rel).to());
             const queryResult = query.build();
-            expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0)-[var1]->(this2)"`);
+            expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0)-[var1]->()"`);
 
             expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });

--- a/src/pattern/Pattern.ts
+++ b/src/pattern/Pattern.ts
@@ -22,7 +22,6 @@ import { CypherEnvironment } from "../Environment";
 import { WithWhere } from "../clauses/mixins/sub-clauses/WithWhere";
 import { mixin } from "../clauses/utils/mixin";
 import type { LabelExpr } from "../expressions/labels/label-expressions";
-import { RelationshipRef } from "../references/RelationshipRef";
 import { Variable } from "../references/Variable";
 import type { Expr } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
@@ -81,12 +80,7 @@ export class Pattern extends PatternElement {
         if (ref instanceof Variable) {
             return new PartialPattern(ref, options ?? {}, this);
         } else {
-            // Emulates previous behaviour
-            let fakeRef: RelationshipRef | undefined;
-            if (!ref && !options) {
-                fakeRef = new RelationshipRef();
-            }
-            return new PartialPattern(fakeRef, options ?? ref ?? {}, this);
+            return new PartialPattern(undefined, options ?? ref ?? {}, this);
         }
     }
 

--- a/tests/console-log.test.ts
+++ b/tests/console-log.test.ts
@@ -68,20 +68,20 @@ describe("Console.log", () => {
         const pattern = new Cypher.Pattern(a).related().to();
 
         expect(`${pattern}`).toMatchInlineSnapshot(`
-            "<Pattern> \\"\\"\\"
-                (this0)-[this1]->(this2)
-            \\"\\"\\""
-        `);
+"<Pattern> \\"\\"\\"
+    (this0)-[this1]->()
+\\"\\"\\""
+`);
         expect(pattern.toString()).toMatchInlineSnapshot(`
-            "<Pattern> \\"\\"\\"
-                (this0)-[this1]->(this2)
-            \\"\\"\\""
-        `);
+"<Pattern> \\"\\"\\"
+    (this0)-[this1]->()
+\\"\\"\\""
+`);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((pattern as any)[customInspectSymbol]()).toMatchInlineSnapshot(`
-            "<Pattern> \\"\\"\\"
-                (this0)-[this1]->(this2)
-            \\"\\"\\""
-        `);
+"<Pattern> \\"\\"\\"
+    (this0)-[this1]->()
+\\"\\"\\""
+`);
     });
 });

--- a/tests/console-log.test.ts
+++ b/tests/console-log.test.ts
@@ -69,18 +69,18 @@ describe("Console.log", () => {
 
         expect(`${pattern}`).toMatchInlineSnapshot(`
 "<Pattern> \\"\\"\\"
-    (this0)-[this1]->()
+    (this0)-[]->()
 \\"\\"\\""
 `);
         expect(pattern.toString()).toMatchInlineSnapshot(`
 "<Pattern> \\"\\"\\"
-    (this0)-[this1]->()
+    (this0)-[]->()
 \\"\\"\\""
 `);
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         expect((pattern as any)[customInspectSymbol]()).toMatchInlineSnapshot(`
 "<Pattern> \\"\\"\\"
-    (this0)-[this1]->()
+    (this0)-[]->()
 \\"\\"\\""
 `);
     });

--- a/tests/variable-escaping.test.ts
+++ b/tests/variable-escaping.test.ts
@@ -42,9 +42,9 @@ describe("Variable escaping", () => {
 
         const { cypher, params } = match.build();
         expect(cypher).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)-[\`my \`\`rel\`:Movie]->(this1)
-            RETURN \`my \`\`rel\`"
-        `);
+"MATCH (this0:Movie)-[\`my \`\`rel\`:Movie]->()
+RETURN \`my \`\`rel\`"
+`);
         expect(params).toMatchInlineSnapshot(`{}`);
     });
 
@@ -87,9 +87,9 @@ describe("Variable escaping", () => {
 
         const { cypher, params } = match.build();
         expect(cypher).toMatchInlineSnapshot(`
-            "MATCH \`my path\` = (this0:Movie)-[this1:Movie]->(this2)
-            RETURN this1"
-        `);
+"MATCH \`my path\` = (this0:Movie)-[this1:Movie]->()
+RETURN this1"
+`);
         expect(params).toMatchInlineSnapshot(`{}`);
     });
 });


### PR DESCRIPTION
Probably an error in the update to 2.x, the nested relationships and nodes of a pattern still create default variables, which is not the expected behaviour for 2.x