### PR TITLE
Add CypherRawContext

### DIFF
--- a/.changeset/calm-pumas-crash.md
+++ b/.changeset/calm-pumas-crash.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecates `CypherEnvironment` exported types in favor of `RawCypherContext` for usafe in `Cypher.Raw`

--- a/.changeset/calm-pumas-crash.md
+++ b/.changeset/calm-pumas-crash.md
@@ -2,4 +2,4 @@
 "@neo4j/cypher-builder": patch
 ---
 
-Deprecates `CypherEnvironment` exported types in favor of `RawCypherContext` for usafe in `Cypher.Raw`
+Deprecates `CypherEnvironment` exported types in favor of `RawCypherContext` for usage in `Cypher.Raw`

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -164,6 +164,7 @@ export { CypherProcedure as Procedure, VoidCypherProcedure as VoidProcedure } fr
 
 // Types
 export type { BuildConfig, Clause } from "./clauses/Clause";
+export type { RawCypherContext } from "./clauses/Raw";
 export type { Order } from "./clauses/sub-clauses/OrderBy";
 export type { ProjectionColumn } from "./clauses/sub-clauses/Projection";
 export type { SetParam } from "./clauses/sub-clauses/Set";

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -36,7 +36,8 @@ const defaultConfig: EnvConfig = {
 };
 
 /** Hold the internal references of Cypher parameters and variables
- *  @group Internal
+ * @group Internal
+ * @deprecated Use `RawCypherContext` interface instead
  */
 export class CypherEnvironment {
     private readonly globalPrefix: EnvPrefix;

--- a/src/clauses/Raw.test.ts
+++ b/src/clauses/Raw.test.ts
@@ -44,7 +44,7 @@ describe("Raw Cypher", () => {
     test("Create a custom query with Raw callback", () => {
         const releasedParam = new Cypher.Param(1999);
 
-        const rawCypher = new Cypher.Raw((env: Cypher.Environment) => {
+        const rawCypher = new Cypher.Raw((env: Cypher.RawCypherContext) => {
             const releasedParamId = env.compile(releasedParam); // Gets the raw Cypher for the param
 
             const customCypher = `MATCH(n) WHERE n.title=$title_param AND n.released=${releasedParamId}`;

--- a/src/clauses/Raw.ts
+++ b/src/clauses/Raw.ts
@@ -18,6 +18,7 @@
  */
 
 import type { CypherEnvironment } from "../Environment";
+import type { CypherCompilable } from "../types";
 import { toCypherParams } from "../utils/to-cypher-params";
 import { Clause } from "./Clause";
 
@@ -62,3 +63,8 @@ export class Raw extends Clause {
  * @deprecated Use {@link Raw} instead
  */
 export class RawCypher extends Raw {}
+
+export interface RawCypherContext {
+    /** Compiles a Cypher element in the current context */
+    compile(element: CypherCompilable): string;
+}


### PR DESCRIPTION
Deprecates `CypherEnvironment` exported types in favor of `RawCypherContext` for usafe in `Cypher.Raw`

This is to provide a smoother migration between v1 and v2