### PR TITLE
Remove env prefix object support

### DIFF
--- a/.changeset/thin-walls-rhyme.md
+++ b/.changeset/thin-walls-rhyme.md
@@ -1,0 +1,14 @@
+---
+"@neo4j/cypher-builder": major
+---
+
+Remove support for fine-grained prefix configuration
+
+No longer supported:
+
+```js
+myClause.build({
+    variable: "var_prefix_",
+    params: "param_prefix_",
+});
+```

--- a/docs/modules/ROOT/pages/migration-guide-2.adoc
+++ b/docs/modules/ROOT/pages/migration-guide-2.adoc
@@ -259,6 +259,29 @@ myClause.build({
 
 All parameters are optional, and `build` can still be called without parameters.
 
+=== Remove support for fine-grained prefix
+
+The prefix parameter prefix for the `.build` method in 1.x supports passing an object with the parameters `params` and `variables` for fine grained control of what prefix to use in different kind of variables. This has been removed in 2.x, supporting only a `string` as global prefix:
+
+No longer supported:
+[source, javascript]
+----
+myClause.build({
+    variable: "var_prefix_",
+    params: "param_prefix_"
+});
+----
+
+Instead, a single string can be used as prefix for bother, variables and params:
+
+Now:
+[source, javascript]
+----
+myClause.build({
+    prefix: "my-custom-prefix"
+});
+----
+
 == `With`
 
 The method `.with` no longer adds new columns into the existing clause. It will always create a new `WITH` statement instead. The method `.addColumns` should be used instead to add extra columns. 

--- a/src/Environment.test.ts
+++ b/src/Environment.test.ts
@@ -67,34 +67,5 @@ describe("Environment", () => {
             expect(paramId).toBe("my-prefixparam0");
             expect(variableId).toBe("my-prefixvar0");
         });
-
-        test("environment with an object prefix", () => {
-            const environment = new CypherEnvironment({
-                params: "p",
-                variables: "v",
-            });
-
-            const variable = new Variable();
-            const param = new Param("my-param");
-
-            const paramId = environment.getReferenceId(param);
-            const variableId = environment.getReferenceId(variable);
-
-            expect(paramId).toBe("pparam0");
-            expect(variableId).toBe("vvar0");
-        });
-
-        test("environment with an object prefix with default values", () => {
-            const environment = new CypherEnvironment({});
-
-            const variable = new Variable();
-            const param = new Param("my-param");
-
-            const paramId = environment.getReferenceId(param);
-            const variableId = environment.getReferenceId(variable);
-
-            expect(paramId).toBe("param0");
-            expect(variableId).toBe("var0");
-        });
     });
 });

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -37,7 +37,7 @@ const defaultConfig: EnvConfig = {
  * @group Internal
  */
 export class CypherEnvironment {
-    private readonly globalPrefix: EnvPrefix;
+    private readonly globalPrefix: string;
 
     private readonly references: Map<Variable, string> = new Map();
     private readonly params: Param[] = [];
@@ -47,18 +47,8 @@ export class CypherEnvironment {
     /**
      *  @internal
      */
-    constructor(prefix?: string | EnvPrefix, config: Partial<EnvConfig> = {}) {
-        if (!prefix || typeof prefix === "string") {
-            this.globalPrefix = {
-                params: prefix ?? "",
-                variables: prefix ?? "",
-            };
-        } else {
-            this.globalPrefix = {
-                params: prefix.params ?? "",
-                variables: prefix.variables ?? "",
-            };
-        }
+    constructor(prefix?: string, config: Partial<EnvConfig> = {}) {
+        this.globalPrefix = prefix ?? "";
 
         this.config = {
             ...defaultConfig,
@@ -112,12 +102,12 @@ export class CypherEnvironment {
         const paramIndex = this.getParamsSize(); // Indexes are separate for readability reasons
 
         if (variable instanceof Param) {
-            const varId = `${this.globalPrefix.params}${variable.prefix}${paramIndex}`;
+            const varId = `${this.globalPrefix}${variable.prefix}${paramIndex}`;
             return this.addParam(varId, variable);
         }
 
         const varIndex = this.references.size - paramIndex;
-        const varId = `${this.globalPrefix.variables}${variable.prefix}${varIndex}`;
+        const varId = `${this.globalPrefix}${variable.prefix}${varIndex}`;
         this.references.set(variable, varId);
         return varId;
     }

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -18,7 +18,7 @@
  */
 
 import { CypherASTNode } from "../CypherASTNode";
-import type { EnvConfig, EnvPrefix } from "../Environment";
+import type { EnvConfig } from "../Environment";
 import { CypherEnvironment } from "../Environment";
 import type { CypherResult } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
@@ -42,7 +42,7 @@ export abstract class Clause extends CypherASTNode {
         extraParams = {},
         labelOperator = ":",
     }: {
-        prefix?: string | EnvPrefix;
+        prefix?: string;
         extraParams?: Record<string, unknown>;
         labelOperator?: ":" | "&";
     } = {}): CypherResult {
@@ -66,7 +66,7 @@ export abstract class Clause extends CypherASTNode {
         throw new Error(`Cannot build root: ${root.constructor.name}`);
     }
 
-    private getEnv(prefix?: string | EnvPrefix, config: BuildConfig = {}): CypherEnvironment {
+    private getEnv(prefix?: string, config: BuildConfig = {}): CypherEnvironment {
         return new CypherEnvironment(prefix, config);
     }
 


### PR DESCRIPTION

Remove support for fine-grained prefix configuration

No longer supported:

```js
myClause.build({
    variable: "var_prefix_",
    params: "param_prefix_",
});
```