### PR TITLE
Deprecate separate params for build

### DIFF
--- a/.changeset/odd-singers-knock.md
+++ b/.changeset/odd-singers-knock.md
@@ -1,0 +1,23 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecate separate parameters in `.build` in favor of an object:
+
+Before:
+
+```js
+myClause.build("another-this", { myParam: "hello" }, { labelOperator: "&" });
+```
+
+Now:
+
+```js
+myClause.build({
+    prefix: "another-this",
+    extraParams: {
+        myParam: "hello",
+    },
+    labelOperator: "&",
+});
+```

--- a/tests/config/labelOperator.test.ts
+++ b/tests/config/labelOperator.test.ts
@@ -21,15 +21,11 @@ import Cypher from "../../src";
 import { TestClause } from "../../src/utils/TestClause";
 
 describe.each([":", "&"] as const)("Config.labelOperator", (labelOperator) => {
-    const config: Cypher.BuildConfig = {
-        labelOperator,
-    };
-
     test("Pattern", () => {
         const node = new Cypher.Node({ labels: ["Movie", "Film"] });
         const query = new Cypher.Match(node);
 
-        const queryResult = new TestClause(query).build(undefined, {}, config);
+        const queryResult = new TestClause(query).build({ labelOperator });
 
         expect(queryResult.cypher).toBe(`MATCH (this0:Movie${labelOperator}Film)`);
     });
@@ -38,7 +34,7 @@ describe.each([":", "&"] as const)("Config.labelOperator", (labelOperator) => {
         const node = new Cypher.Node({ labels: ["Movie"] });
         const query = new Cypher.Match(node).where(node.hasLabels("Movie", "Film"));
 
-        const queryResult = new TestClause(query).build(undefined, {}, config);
+        const queryResult = new TestClause(query).build({ labelOperator });
 
         expect(queryResult.cypher).toBe(`MATCH (this0:Movie)
 WHERE this0:Movie${labelOperator}Film`);

--- a/tests/deprecated/build.test.ts
+++ b/tests/deprecated/build.test.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../../src";
+import { TestClause } from "../../src/utils/TestClause";
+
+describe("Variable escaping", () => {
+    test("Should escape prefix", () => {
+        const movie = new Cypher.Node({ labels: ["My Movie"] });
+        const match = new Cypher.Match(movie).return(movie);
+
+        const { cypher, params } = match.build("my prefix");
+
+        expect(cypher).toMatchInlineSnapshot(`
+        "MATCH (\`my prefixthis0\`:\`My Movie\`)
+        RETURN \`my prefixthis0\`"
+    `);
+        expect(params).toMatchInlineSnapshot(`{}`);
+    });
+
+    describe.each([":", "&"] as const)("Config.labelOperator", (labelOperator) => {
+        const config: Cypher.BuildConfig = {
+            labelOperator,
+        };
+
+        test("Pattern", () => {
+            const node = new Cypher.Node({ labels: ["Movie", "Film"] });
+            const query = new Cypher.Match(node);
+
+            const queryResult = new TestClause(query).build(undefined, {}, config);
+
+            expect(queryResult.cypher).toBe(`MATCH (this0:Movie${labelOperator}Film)`);
+        });
+
+        test("hasLabel", () => {
+            const node = new Cypher.Node({ labels: ["Movie"] });
+            const query = new Cypher.Match(node).where(node.hasLabels("Movie", "Film"));
+
+            const queryResult = new TestClause(query).build(undefined, {}, config);
+
+            expect(queryResult.cypher).toBe(`MATCH (this0:Movie)
+WHERE this0:Movie${labelOperator}Film`);
+        });
+    });
+});

--- a/tests/variable-escaping.test.ts
+++ b/tests/variable-escaping.test.ts
@@ -64,7 +64,7 @@ describe("Variable escaping", () => {
         const movie = new Cypher.Node({ labels: ["My Movie"] });
         const match = new Cypher.Match(movie).return(movie);
 
-        const { cypher, params } = match.build("my prefix");
+        const { cypher, params } = match.build({ prefix: "my prefix" });
 
         expect(cypher).toMatchInlineSnapshot(`
             "MATCH (\`my prefixthis0\`:\`My Movie\`)


### PR DESCRIPTION
This deprecation allows for a soft migration from 1.x to 2.x


Deprecate separate parameters in `.build` in favor of an object:

Before:

```js
myClause.build("another-this", { myParam: "hello" }, { labelOperator: "&" });
```

Now:

```js
myClause.build({
    prefix: "another-this",
    extraParams: {
        myParam: "hello",
    },
    labelOperator: "&",
});
```