### PR TITLE
Fix types in unwind

### DIFF
--- a/.changeset/lovely-planets-occur.md
+++ b/.changeset/lovely-planets-occur.md
@@ -2,4 +2,8 @@
 "@neo4j/cypher-builder": patch
 ---
 
-Fix types in `Unwind`. Unwind without alias is not supported in Cypher.
+Fix types in `Unwind` to reflect its behaviour in Cypher:
+
+-   Unwind without alias is not supported in Cypher.
+-   Unwind does not support `*`
+-   Unwind does not support multiple columns

--- a/.changeset/lovely-planets-occur.md
+++ b/.changeset/lovely-planets-occur.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Fix types in `Unwind`. Unwind without alias is not supported in Cypher.

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -28,7 +28,7 @@ export { Merge } from "./clauses/Merge";
 export { Raw, type RawCypherContext } from "./clauses/Raw";
 export { Return } from "./clauses/Return";
 export { Union } from "./clauses/Union";
-export { Unwind } from "./clauses/Unwind";
+export { Unwind, type UnwindProjectionColumn } from "./clauses/Unwind";
 export { Use } from "./clauses/Use";
 export { With } from "./clauses/With";
 

--- a/src/clauses/Unwind.test.ts
+++ b/src/clauses/Unwind.test.ts
@@ -99,7 +99,7 @@ UNWIND var1 AS var2"
 
         expect(() => {
             unwindQuery.unwind([variable, new Cypher.Variable()]);
-        }).toThrow("Invalid Unwind statement");
+        }).toThrow("Cannot add <Clause Unwind> to <Clause Unwind> because Unwind it is not the last clause.");
     });
 
     test("Unwind movies with order", () => {

--- a/src/clauses/Unwind.ts
+++ b/src/clauses/Unwind.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import type { Expr, Literal, Variable } from "..";
 import type { CypherEnvironment } from "../Environment";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
 import { Clause } from "./Clause";
@@ -29,7 +30,6 @@ import { WithDelete } from "./mixins/sub-clauses/WithDelete";
 import { WithOrder } from "./mixins/sub-clauses/WithOrder";
 import { WithRemove } from "./mixins/sub-clauses/WithRemove";
 import { WithSet } from "./mixins/sub-clauses/WithSet";
-import type { ProjectionColumn } from "./sub-clauses/Projection";
 import { Projection } from "./sub-clauses/Projection";
 import { mixin } from "./utils/mixin";
 
@@ -44,6 +44,8 @@ export interface Unwind
         WithMerge,
         WithOrder {}
 
+export type UnwindProjectionColumn = [Expr, string | Variable | Literal];
+
 /**
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/unwind/)
  * @category Clauses
@@ -52,12 +54,12 @@ export interface Unwind
 export class Unwind extends Clause {
     private readonly projection: Projection;
 
-    constructor(...columns: Array<ProjectionColumn>) {
+    constructor(...columns: Array<UnwindProjectionColumn>) {
         super();
         this.projection = new Projection(columns);
     }
 
-    public addColumns(...columns: Array<"*" | ProjectionColumn>): void {
+    public addColumns(...columns: Array<UnwindProjectionColumn>): void {
         this.projection.addColumns(columns);
     }
 
@@ -66,8 +68,8 @@ export class Unwind extends Clause {
      * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/unwind/)
      */
     public unwind(clause: Unwind): Unwind;
-    public unwind(...columns: Array<ProjectionColumn>): Unwind;
-    public unwind(clauseOrColumn: Unwind | ProjectionColumn, ...columns: Array<ProjectionColumn>): Unwind {
+    public unwind(...columns: Array<UnwindProjectionColumn>): Unwind;
+    public unwind(clauseOrColumn: Unwind | UnwindProjectionColumn, ...columns: Array<UnwindProjectionColumn>): Unwind {
         if (clauseOrColumn instanceof Unwind) {
             this.addNextClause(clauseOrColumn);
             return clauseOrColumn;
@@ -90,7 +92,7 @@ export class Unwind extends Clause {
         return `UNWIND ${projectionStr}${setCypher}${removeCypher}${deleteCypher}${orderCypher}${nextClause}`;
     }
 
-    private addColumnsToUnwindClause(...columns: Array<"*" | ProjectionColumn>): Unwind {
+    private addColumnsToUnwindClause(...columns: Array<UnwindProjectionColumn>): Unwind {
         if (!this.nextClause) {
             this.addNextClause(new Unwind());
         }

--- a/src/clauses/mixins/clauses/WithUnwind.ts
+++ b/src/clauses/mixins/clauses/WithUnwind.ts
@@ -26,21 +26,18 @@ export abstract class WithUnwind extends MixinClause {
      * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/unwind/)
      */
     public unwind(clause: Unwind): Unwind;
-    public unwind(...columns: Array<UnwindProjectionColumn>): Unwind;
-    public unwind(clauseOrColumn: Unwind | UnwindProjectionColumn, ...columns: Array<UnwindProjectionColumn>): Unwind {
-        const unwindClause = this.getUnwindClause(clauseOrColumn, columns);
+    public unwind(projection: UnwindProjectionColumn): Unwind;
+    public unwind(clauseOrColumn: Unwind | UnwindProjectionColumn): Unwind {
+        const unwindClause = this.getUnwindClause(clauseOrColumn);
         this.addNextClause(unwindClause);
         return unwindClause;
     }
 
-    private getUnwindClause(
-        clauseOrColumn: Unwind | UnwindProjectionColumn,
-        columns: Array<UnwindProjectionColumn>
-    ): Unwind {
+    private getUnwindClause(clauseOrColumn: Unwind | UnwindProjectionColumn): Unwind {
         if (clauseOrColumn instanceof Unwind) {
             return clauseOrColumn;
         } else {
-            return new Unwind(clauseOrColumn, ...columns);
+            return new Unwind(clauseOrColumn);
         }
     }
 }

--- a/src/clauses/mixins/clauses/WithUnwind.ts
+++ b/src/clauses/mixins/clauses/WithUnwind.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import type { ProjectionColumn } from "../../sub-clauses/Projection";
+import type { UnwindProjectionColumn } from "../../Unwind";
 import { Unwind } from "../../Unwind";
 import { MixinClause } from "../Mixin";
 
@@ -26,14 +26,17 @@ export abstract class WithUnwind extends MixinClause {
      * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/clauses/unwind/)
      */
     public unwind(clause: Unwind): Unwind;
-    public unwind(...columns: Array<ProjectionColumn>): Unwind;
-    public unwind(clauseOrColumn: Unwind | ProjectionColumn, ...columns: Array<ProjectionColumn>): Unwind {
+    public unwind(...columns: Array<UnwindProjectionColumn>): Unwind;
+    public unwind(clauseOrColumn: Unwind | UnwindProjectionColumn, ...columns: Array<UnwindProjectionColumn>): Unwind {
         const unwindClause = this.getUnwindClause(clauseOrColumn, columns);
         this.addNextClause(unwindClause);
         return unwindClause;
     }
 
-    private getUnwindClause(clauseOrColumn: Unwind | ProjectionColumn, columns: Array<ProjectionColumn>): Unwind {
+    private getUnwindClause(
+        clauseOrColumn: Unwind | UnwindProjectionColumn,
+        columns: Array<UnwindProjectionColumn>
+    ): Unwind {
         if (clauseOrColumn instanceof Unwind) {
             return clauseOrColumn;
         } else {

--- a/tests/clause-chaining.test.ts
+++ b/tests/clause-chaining.test.ts
@@ -138,7 +138,7 @@ describe("Clause chaining", () => {
     });
 
     describe("Unwind", () => {
-        const clause = new Cypher.Unwind();
+        const clause = new Cypher.Unwind([new Cypher.Variable(), "a"]);
 
         it.each([
             "return",


### PR DESCRIPTION
An UNWIND without alias is not supported in Cypher, yet it is allowed in cypher builder