### PR TITLE
Escape keywords in variable names

### DIFF
--- a/.changeset/twenty-falcons-help.md
+++ b/.changeset/twenty-falcons-help.md
@@ -1,0 +1,22 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Escapes variables using the following reserved words (case insensitive):
+
+- `where`
+- `is`
+- `contains`
+- `in`
+
+For example:
+
+```js
+new Cypher.NamedVariable("Where").property("title");
+```
+
+Generates the following Cypher
+
+```cypher
+`Where`.title
+```

--- a/src/references/Variable.test.ts
+++ b/src/references/Variable.test.ts
@@ -53,4 +53,25 @@ describe("Variable", () => {
 
         expect(new TestClause(variableProp).build().cypher).toMatchInlineSnapshot(`"var0[($param0 + \\"bar\\")]"`);
     });
+
+    test("does not escape named variable with valid name", () => {
+        const variableProp = new Cypher.NamedVariable("MyVariable").property("title");
+
+        expect(new TestClause(variableProp).build().cypher).toMatchInlineSnapshot(`"MyVariable.title"`);
+    });
+
+    test("escapes named variable", () => {
+        const variableProp = new Cypher.NamedVariable("My Variable").property("my title");
+
+        expect(new TestClause(variableProp).build().cypher).toMatchInlineSnapshot(`"\`My Variable\`.\`my title\`"`);
+    });
+
+    test.each(["where", "is", "contains", "in", "WHERE", "Is"])(
+        "escapes named variable with reserved keyword: %s",
+        (keyword) => {
+            const variableProp = new Cypher.NamedVariable(keyword).property("title");
+
+            expect(new TestClause(variableProp).build().cypher).toEqual(`\`${keyword}\`.title`);
+        }
+    );
 });

--- a/src/utils/escape.ts
+++ b/src/utils/escape.ts
@@ -19,6 +19,9 @@
 
 const ESCAPE_SYMBOL_REGEX = /`/g;
 
+/** These names must be escaped for variables */
+const RESERVED_VAR_NAMES = ["contains", "in", "where", "is"];
+
 /** Escapes a Node label string */
 export function escapeLabel(label: string): string {
     return escapeIfNeeded(label);
@@ -26,7 +29,8 @@ export function escapeLabel(label: string): string {
 
 /** Escapes a Relationship type string */
 export function escapeType(type: string): string {
-    return escapeIfNeeded(type);
+    // Use same logic as escape label
+    return escapeLabel(type);
 }
 
 /** Escapes a property name string */
@@ -36,6 +40,9 @@ export function escapeProperty(propName: string): string {
 
 /** Escapes a variable name if needed */
 export function escapeVariable(varName: string): string {
+    if (RESERVED_VAR_NAMES.includes(varName.toLowerCase())) {
+        return escapeString(varName);
+    }
     return escapeIfNeeded(varName);
 }
 
@@ -47,10 +54,15 @@ export function escapeLiteralString(str: string): string {
 function escapeIfNeeded(str: string): string {
     const normalizedStr = normalizeString(str);
     if (needsEscape(normalizedStr)) {
-        const escapedLabel = normalizedStr.replace(ESCAPE_SYMBOL_REGEX, "``");
-        return `\`${escapedLabel}\``;
+        return escapeString(normalizedStr);
     }
     return normalizedStr;
+}
+
+function escapeString(str: string): string {
+    const normalizedStr = normalizeString(str);
+    const escapedStr = normalizedStr.replace(ESCAPE_SYMBOL_REGEX, "``");
+    return `\`${escapedStr}\``;
 }
 
 function normalizeString(str: string): string {


### PR DESCRIPTION
Since version 5.26, Cypher variables using certain names are deprecated and should be escaped.

Escapes variables using the following reserved words (case insensitive):

- `where`
- `is`
- `contains`
- `in`

For example:

```js
new Cypher.NamedVariable("Where").property("title");
```

Generates the following Cypher

```cypher
`Where`.title
```