### PR TITLE
Add withHeaders to loadCSV

### DIFF
--- a/.changeset/friendly-mugs-try.md
+++ b/.changeset/friendly-mugs-try.md
@@ -1,0 +1,13 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Add support for `WITH HEADERS` in `LoadCSV`:
+
+```js
+new Cypher.LoadCSV("https://data.neo4j.com/bands/artists.csv", new Cypher.Variable()).withHeaders();
+```
+
+```cypher
+LOAD CSV WITH HEADERS FROM \\"https://data.neo4j.com/bands/artists.csv\\" AS var0
+```

--- a/src/clauses/LoadCSV.test.ts
+++ b/src/clauses/LoadCSV.test.ts
@@ -32,4 +32,28 @@ RETURN var0"
 
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
+
+    test("LoadCSV with headers", () => {
+        const row = new Cypher.Variable();
+        const node = new Cypher.Node();
+        const loadClause = new Cypher.LoadCSV("https://data.neo4j.com/bands/artists.csv", row)
+            .withHeaders()
+            .merge(
+                new Cypher.Pattern(node, {
+                    properties: {
+                        name: row.property("Name"),
+                    },
+                })
+            )
+            .return(row);
+
+        const queryResult = loadClause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"LOAD CSV WITH HEADERS FROM \\"https://data.neo4j.com/bands/artists.csv\\" AS var0
+MERGE (this1 { name: var0.Name })
+RETURN var0"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
 });

--- a/src/clauses/LoadCSV.ts
+++ b/src/clauses/LoadCSV.ts
@@ -39,10 +39,17 @@ export class LoadCSV extends Clause {
     private readonly url: string;
     private readonly alias: Variable;
 
+    private _withHeaders = false;
+
     constructor(url: string, alias: Variable) {
         super();
         this.url = url;
         this.alias = alias;
+    }
+
+    public withHeaders(): this {
+        this._withHeaders = true;
+        return this;
     }
 
     /**
@@ -51,6 +58,7 @@ export class LoadCSV extends Clause {
     public getCypher(env: CypherEnvironment): string {
         const aliasStr = this.alias.getCypher(env);
         const nextClause = this.compileNextClause(env);
-        return `LOAD CSV FROM "${this.url}" AS ${aliasStr}${nextClause}`;
+        const withHeadersStr = this._withHeaders ? "WITH HEADERS " : "";
+        return `LOAD CSV ${withHeadersStr}FROM "${this.url}" AS ${aliasStr}${nextClause}`;
     }
 }


### PR DESCRIPTION
Add support for `WITH HEADERS` in `LoadCSV`:

```js
new Cypher.LoadCSV("https://data.neo4j.com/bands/artists.csv", new Cypher.Variable()).withHeaders();
```

```cypher
LOAD CSV WITH HEADERS FROM \\"https://data.neo4j.com/bands/artists.csv\\" AS var0
```