### PR TITLE
Export some types returned by some parts of the CypherBuilder

### DIFF
--- a/.changeset/forty-kiwis-grow.md
+++ b/.changeset/forty-kiwis-grow.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Export the following types: `When`, `IsType`, `ListType`, `BooleanOp` `MathOp`. These types were returned by some functions or methods, but the types themselves were not exported.

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "neo4j-driver": "^5.26.0",
         "prettier": "^3.4.1",
         "ts-jest": "^29.2.5",
-        "typedoc": "^0.27.5",
+        "typedoc": "^0.27.6",
         "typescript": "^5.6.3"
     }
 }

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -48,8 +48,8 @@ export { NamedRelationship, RelationshipRef as Relationship } from "./references
 export { NamedVariable, Variable } from "./references/Variable";
 
 // Expressions
-export { Case } from "./expressions/Case";
-export { CypherTypes as TYPE, isNotType, isType } from "./expressions/IsType";
+export { Case, type When } from "./expressions/Case";
+export { CypherTypes as TYPE, isNotType, isType, type IsType, type ListType } from "./expressions/IsType";
 
 // Subquery Expressions
 export { Collect } from "./expressions/subquery/Collect";
@@ -74,7 +74,7 @@ export { MapExpr as Map } from "./expressions/map/MapExpr";
 export { MapProjection } from "./expressions/map/MapProjection";
 
 // --Operations
-export { and, not, or, xor } from "./expressions/operations/boolean";
+export { and, not, or, xor, type BooleanOp } from "./expressions/operations/boolean";
 export {
     contains,
     endsWith,
@@ -91,8 +91,9 @@ export {
     matches,
     neq,
     startsWith,
+    type ComparisonOp,
 } from "./expressions/operations/comparison";
-export { divide, minus, mod, multiply, plus, pow } from "./expressions/operations/math";
+export { divide, minus, mod, multiply, plus, pow, type MathOp } from "./expressions/operations/math";
 
 // --Functions
 export { CypherFunction as Function } from "./expressions/functions/CypherFunctions";
@@ -167,8 +168,6 @@ export type { CypherAggregationFunction as AggregationFunction } from "./express
 export type { PredicateFunction } from "./expressions/functions/predicate";
 export type { HasLabel } from "./expressions/HasLabel";
 export type { LabelExpr, LabelOperator } from "./expressions/labels/label-expressions";
-export type { BooleanOp } from "./expressions/operations/boolean";
-export type { ComparisonOp } from "./expressions/operations/comparison";
 export type { PathAssign } from "./pattern/PathAssign";
 export type { Yield } from "./procedures/Yield";
 export type { Label } from "./references/Label";

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -18,7 +18,6 @@
  */
 
 import { CypherASTNode } from "../CypherASTNode";
-import type { EnvConfig } from "../Environment";
 import { CypherEnvironment } from "../Environment";
 import type { CypherResult } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
@@ -28,7 +27,9 @@ import { toCypherParams } from "../utils/to-cypher-params";
 const customInspectSymbol = Symbol.for("nodejs.util.inspect.custom");
 
 /** Config fields for the .build method */
-export type BuildConfig = Partial<EnvConfig>;
+export type BuildConfig = Partial<{
+    labelOperator: ":" | "&";
+}>;
 
 /** Represents a clause AST node
  *  @group Internal

--- a/src/expressions/Case.ts
+++ b/src/expressions/Case.ts
@@ -63,11 +63,12 @@ export class Case<C extends Expr | undefined = undefined> extends CypherASTNode 
     }
 }
 
-class When<T extends Expr | undefined> extends CypherASTNode {
+export class When<T extends Expr | undefined> extends CypherASTNode {
     protected parent: Case<T>;
     private readonly predicates: Expr[];
     private result: Expr | undefined;
 
+    /** @internal */
     constructor(parent: Case<T>, predicate: Expr[]) {
         super(parent);
         this.parent = parent;

--- a/src/expressions/IsType.ts
+++ b/src/expressions/IsType.ts
@@ -49,6 +49,8 @@ const BaseTypes = {
     TIME_WITH_TIME_ZONE: "TIME WITH TIME ZONE",
 } as const;
 
+type Type = ValueOf<typeof BaseTypes> | ListType;
+
 /**
  * Generates a cypher `LIST<...>` type
  * @example
@@ -93,10 +95,11 @@ export function isNotType(expr: Expr, type: Type | Type[]): IsType {
     return new IsType(expr, asArray(type), true);
 }
 
-class ListType {
+export class ListType {
     private readonly types: Type[];
     private _notNull: boolean = false;
 
+    /** @internal */
     constructor(type: Type[]) {
         this.types = type;
     }
@@ -127,6 +130,7 @@ export class IsType extends CypherASTNode {
     private readonly not: boolean;
     private _notNull: boolean = false;
 
+    /** @internal */
     public constructor(expr: Expr, type: Type[], not = false) {
         super();
         this.expr = expr;
@@ -156,8 +160,6 @@ export class IsType extends CypherASTNode {
         return `${exprCypher} ${isStr} :: ${typesStr}`;
     }
 }
-
-type Type = ValueOf<typeof BaseTypes> | ListType;
 
 function compileType(type: Type, env: CypherEnvironment): string {
     if (type instanceof ListType) {

--- a/src/expressions/operations/boolean.ts
+++ b/src/expressions/operations/boolean.ts
@@ -30,6 +30,7 @@ type BooleanOperator = "AND" | "NOT" | "OR" | "XOR";
 export abstract class BooleanOp extends CypherASTNode {
     protected operator: BooleanOperator;
 
+    /** @internal */
     constructor(operator: BooleanOperator) {
         super();
         this.operator = operator;
@@ -39,6 +40,7 @@ export abstract class BooleanOp extends CypherASTNode {
 class BinaryOp extends BooleanOp {
     private readonly children: Predicate[];
 
+    /** @internal */
     constructor(operator: BooleanOperator, predicates: Predicate[]) {
         super(operator);
         this.children = predicates;

--- a/src/expressions/operations/comparison.ts
+++ b/src/expressions/operations/comparison.ts
@@ -46,6 +46,7 @@ export class ComparisonOp extends CypherASTNode {
     protected leftExpr: Expr;
     protected rightExpr: Expr | undefined;
 
+    /** @internal */
     constructor(operator: ComparisonOperator, left: Expr, right: Expr | undefined) {
         super();
         this.operator = operator;

--- a/src/expressions/operations/math.ts
+++ b/src/expressions/operations/math.ts
@@ -27,6 +27,7 @@ export class MathOp extends CypherASTNode {
     private readonly operator: MathOperator;
     private readonly exprs: Expr[];
 
+    /** @internal */
     constructor(operator: MathOperator, exprs: Expr[]) {
         super();
         this.operator = operator;

--- a/src/namespaces/db/index/fulltext.ts
+++ b/src/namespaces/db/index/fulltext.ts
@@ -33,7 +33,7 @@ const FULLTEXT_NAMESPACE = "db.index.fulltext";
  */
 export function queryNodes(
     indexName: string | Literal<string>,
-    queryString: FulltextPhrase,
+    queryString: string | Literal<string> | Param | Variable,
     options?: { skip?: InputArgument<number>; limit?: InputArgument<number>; analyser?: InputArgument<string> }
 ): CypherProcedure<"node" | "score"> {
     const procedureArgs = getFulltextArguments(indexName, queryString, options);
@@ -47,7 +47,7 @@ export function queryNodes(
  */
 export function queryRelationships(
     indexName: string | Literal<string>,
-    queryString: FulltextPhrase,
+    queryString: string | Literal<string> | Param | Variable,
     options?: { skip?: InputArgument<number>; limit?: InputArgument<number>; analyser?: InputArgument<string> }
 ): CypherProcedure<"relationship" | "score"> {
     const procedureArgs = getFulltextArguments(indexName, queryString, options);


### PR DESCRIPTION
Export the following types: `When`, `IsType`, `ListType`, `BooleanOp` `MathOp`. These types were returned by some functions or methods, but the types themselves were not exported.

This partially fixes #466 