### PR TITLE
Add support for maps assignment to nodes

### DIFF
--- a/.changeset/quick-tables-begin.md
+++ b/.changeset/quick-tables-begin.md
@@ -1,0 +1,21 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Support for assigning maps and variables directly to variables with `.set` to override all properties of a node:
+
+```js
+new Cypher.Match(new Cypher.Pattern(movie)).set([
+    movie,
+    new Cypher.Map({
+        title: new Cypher.Param("The Matrix"),
+        year: new Cypher.Param(1999),
+    }),
+]);
+```
+
+```cypher
+MATCH (this0)
+SET
+    this0 = { title: $param0, year: $param1 }
+```

--- a/src/clauses/sub-clauses/Set.test.ts
+++ b/src/clauses/sub-clauses/Set.test.ts
@@ -113,4 +113,45 @@ SET
 }
 `);
     });
+
+    test("Set node to map", () => {
+        const movie = new Cypher.Node();
+        const clause = new Cypher.Match(new Cypher.Pattern(movie)).set([
+            movie,
+            new Cypher.Map({
+                title: new Cypher.Param("The Matrix"),
+                year: new Cypher.Param(1999),
+            }),
+        ]);
+
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+SET
+    this0 = { title: $param0, year: $param1 }"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`
+{
+  "param0": "The Matrix",
+  "param1": 1999,
+}
+`);
+    });
+
+    test("Set node to variable", () => {
+        const movie = new Cypher.Node();
+        const actor = new Cypher.Node();
+        const clause = new Cypher.Match(new Cypher.Pattern(movie, { labels: ["Movie"] }))
+            .match(new Cypher.Pattern(actor, { labels: ["Actor"] }))
+            .set([movie, actor]);
+
+        const queryResult = clause.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Movie)
+MATCH (this1:Actor)
+SET
+    this0 = this1"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
 });

--- a/src/clauses/sub-clauses/Set.ts
+++ b/src/clauses/sub-clauses/Set.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import type { Variable } from "../..";
 import { CypherASTNode } from "../../CypherASTNode";
 import type { CypherEnvironment } from "../../Environment";
 import type { MapExpr } from "../../expressions/map/MapExpr";
@@ -26,7 +27,7 @@ import type { PropertyRef } from "../../references/PropertyRef";
 import type { Expr } from "../../types";
 import { padBlock } from "../../utils/pad-block";
 
-export type SetParam = [PropertyRef, Exclude<Expr, MapExpr | MapProjection>] | Label;
+export type SetParam = [PropertyRef, Exclude<Expr, MapExpr | MapProjection>] | [Variable, MapExpr | Variable] | Label;
 
 export class SetClause extends CypherASTNode {
     protected params: SetParam[];


### PR DESCRIPTION

Support for assigning maps and variables directly to variables with `.set` to override all properties of a node:

```js
new Cypher.Match(new Cypher.Pattern(movie)).set([
    movie,
    new Cypher.Map({
        title: new Cypher.Param("The Matrix"),
        year: new Cypher.Param(1999),
    }),
]);
```

```cypher
MATCH (this0)
SET
    this0 = { title: $param0, year: $param1 }
```