### PR TITLE
Fix typos in migration guide

### DIFF
--- a/docs/modules/ROOT/pages/migration-guide-2.adoc
+++ b/docs/modules/ROOT/pages/migration-guide-2.adoc
@@ -320,7 +320,7 @@ WITH *, this0
 `Cypher.Raw` no longer exposes a `Cypher.Environment` variable. Instead, it provides an instance of `CypherRawContext` with a `compile` method to compile nested elements in custom cypher.
 
 
-Before.
+Before:
 [source, typescript]
 ----
 const releasedParam = new Cypher.Param(1999);
@@ -333,7 +333,7 @@ const rawCypher = new Cypher.Raw((env: Cypher.Environment) => {
 });
 ----
 
-Now.
+Now:
 [source, typescript]
 ----
 const releasedParam = new Cypher.Param(1999);
@@ -435,13 +435,13 @@ new Cypher.Literal(`Hello "World"`);
 
 Would generate the following Cypher:
 
-Before.
+Before:
 [source, cypher]
 ----
 "Hello "World""
 ----
 
-Now.
+Now:
 [source, cypher]
 ----
 "Hello \"World\""

--- a/docs/modules/ROOT/pages/migration-guide-2.adoc
+++ b/docs/modules/ROOT/pages/migration-guide-2.adoc
@@ -261,7 +261,7 @@ All parameters are optional, and `build` can still be called without parameters.
 
 === Remove support for fine-grained prefix
 
-The prefix parameter prefix for the `.build` method in 1.x supports passing an object with the parameters `params` and `variables` for fine grained control of what prefix to use in different kind of variables. This has been removed in 2.x, supporting only a `string` as global prefix:
+The first parameter "prefix" for the `.build` method in 1.x supports passing an object with the parameters `params` and `variables` for fine grained control of what prefix to use in different kind of variables. This has been removed in 2.x, supporting only a `string` as global prefix:
 
 No longer supported:
 [source, javascript]
@@ -272,7 +272,7 @@ myClause.build({
 });
 ----
 
-Instead, a single string can be used as prefix for bother, variables and params:
+Instead, a single string can be used as prefix for both, variables and params:
 
 Now:
 [source, javascript]
@@ -317,10 +317,10 @@ WITH *, this0
 
 === Update callback parameter
 
-`Cypher.Raw`` no longer exposes a `Cypher.Environment` variable. Instead, it provides a `CypherRawContext` instance with a `compile` method to compile nested elements in custom cypher.
+`Cypher.Raw` no longer exposes a `Cypher.Environment` variable. Instead, it provides an instance of `CypherRawContext` with a `compile` method to compile nested elements in custom cypher.
 
 
-Before
+Before.
 [source, typescript]
 ----
 const releasedParam = new Cypher.Param(1999);
@@ -433,15 +433,15 @@ Passing parameters without spread will still return a defined type.
 new Cypher.Literal(`Hello "World"`);
 ----
 
-Would generate the following Cypher
+Would generate the following Cypher:
 
-Before: 
+Before.
 [source, cypher]
 ----
 "Hello "World""
 ----
 
-Now:
+Now.
 [source, cypher]
 ----
 "Hello \"World\""

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "neo4j-driver": "^5.26.0",
         "prettier": "^3.4.1",
         "ts-jest": "^29.2.5",
-        "typedoc": "^0.27.6",
+        "typedoc": "^0.27.7",
         "typescript": "^5.6.3"
     }
 }


### PR DESCRIPTION
Fix some typos in the migration guide and update typedoc