### PR TITLE
504 flag to disable escaping labels and types

### DIFF
--- a/.changeset/shiny-badgers-reply.md
+++ b/.changeset/shiny-badgers-reply.md
@@ -1,0 +1,49 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+New options to disable automatic escaping of labels and relationship types have been added to the `.build` method on clauses, inside the new object `unsafeEscapeOptions`:
+
+- `disableLabelEscaping` (defaults to `false`): If set to true, node labels will not be escaped if unsafe.
+- `disableRelationshipTypeEscaping` (defaults to `false`): If set to true, relationship types will not be escaped if unsafe
+
+For example:
+
+```js
+const personNode = new Cypher.Node();
+const movieNode = new Cypher.Node();
+
+const matchQuery = new Cypher.Match(
+    new Cypher.Pattern(personNode, {
+        labels: ["Person"],
+        properties: {
+            ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+        },
+    })
+        .related({ type: "ACTED IN" })
+        .to(movieNode, { labels: ["A Movie"] })
+).return(personNode);
+
+const queryResult = matchQuery.build({
+    unsafeEscapeOptions: {
+        disableLabelEscaping: true,
+        disableRelationshipTypeEscaping: true,
+    },
+});
+```
+
+This query will generate the following (invalid) Cypher:
+
+```
+MATCH (this0:Person { `person name`: "Uneak \"Seveer" })-[:ACTED IN]->(this1:A Movie)
+RETURN this0
+```
+
+Instead of the default (safe) Cypher:
+
+```cypher
+MATCH (this0:Person { `person name`: "Uneak \"Seveer" })-[:`ACTED IN`]->(this1:`A Movie`)
+RETURN this0
+```
+
+**WARNING:**: Changing these options may lead to code injection and unsafe Cypher.

--- a/docs/modules/ROOT/pages/how-to/customize-cypher.adoc
+++ b/docs/modules/ROOT/pages/how-to/customize-cypher.adoc
@@ -346,3 +346,92 @@ And the following parameters:
 The callback passed into `Raw` is producing the string `this0.prop = $myParam`. 
 To achieve this, it uses the utility method `utils.compileCypher` and passes the variable `movie` and the `context` parameter, which then returns the string `this0`. 
 Finally, the custom parameter `$myParam` is returned in the tuple `[cypher, params]`, ensuring that it is available when executing `match.build()`.
+
+
+== Disable automatic escaping
+
+[WARNING]
+====
+Changing these options may lead to code injection and unsafe Cypher.
+====
+
+Cypher Builder automatically escapes unsafe strings that could lead to code injection. This behavior can be configured using the `unsafeEscapeOptions` parameter in the `.build` method of clauses:
+
+- `disableLabelEscaping` (defaults to `false`): If set to `true`, node labels will not be escaped, even if unsafe.
+- `disableRelationshipTypeEscaping` (defaults to `false`): If set to `true`, relationship types will not be escaped, even if unsafe.
+
+For example:
+
+[source, javascript]
+----
+const personNode = new Cypher.Node();
+const movieNode = new Cypher.Node();
+
+const matchQuery = new Cypher.Match(
+    new Cypher.Pattern(personNode, {
+        labels: ["Person"],
+        properties: {
+            ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+        },
+    })
+        .related({ type: "ACTED IN" })
+        .to(movieNode, { labels: ["A Movie"] })
+).return(personNode);
+
+const queryResult = matchQuery.build({
+    unsafeEscapeOptions: {
+        disableLabelEscaping: true,
+        disableRelationshipTypeEscaping: true,
+    },
+});
+----
+
+This query will generate the following (invalid) Cypher:
+
+
+[source]
+----
+MATCH (this0:Person { `person name`: "Uneak \"Seveer" })-[:ACTED IN]->(this1:A Movie)
+RETURN this0
+----
+
+Instead of the default (safe) Cypher:
+
+[source, cypher]
+----
+MATCH (this0:Person { `person name`: "Uneak \"Seveer" })-[:`ACTED IN`]->(this1:`A Movie`)
+RETURN this0
+----
+
+=== Manually escaping labels and types
+
+If automatic escaping is disabled, strings used for labels and relationship types must be escaped manually. This can be done using the following utility functions:
+
+* `Cypher.utils.escapeLabel(str)`
+* `Cypher.utils.escapeType(str)`
+
+In the previous example, labels and types can be escaped manually to produce valid Cypher:
+
+[source, javascript]
+----
+const personNode = new Cypher.Node();
+const movieNode = new Cypher.Node();
+
+const matchQuery = new Cypher.Match(
+    new Cypher.Pattern(personNode, {
+        labels: [Cypher.utils.escapeLabel("Person")],
+        properties: {
+            ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+        },
+    })
+        .related({ type: Cypher.utils.escapeType("ACTED IN") })
+        .to(movieNode, { labels: [Cypher.utils.escapeLabel("A Movie")] })
+).return(personNode);
+
+const queryResult = matchQuery.build({
+    unsafeEscapeOptions: {
+        disableLabelEscaping: true,
+        disableRelationshipTypeEscaping: true,
+    },
+});
+----

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import type { BuildConfig } from "./Cypher";
 import { Param } from "./references/Param";
 import type { NamedReference, Variable } from "./references/Variable";
 
@@ -26,12 +27,15 @@ export type EnvPrefix = {
 };
 
 export type EnvConfig = {
-    labelOperator: ":" | "&";
-    cypherVersion?: "5";
+    labelOperator: NonNullable<BuildConfig["labelOperator"]>;
+    unsafeEscapeOptions: NonNullable<BuildConfig["unsafeEscapeOptions"]>;
+    cypherVersion: BuildConfig["cypherVersion"];
 };
 
 const defaultConfig: EnvConfig = {
     labelOperator: ":",
+    unsafeEscapeOptions: {},
+    cypherVersion: undefined,
 };
 
 /** Hold the internal references of Cypher parameters and variables

--- a/src/pattern/PartialPattern.ts
+++ b/src/pattern/PartialPattern.ts
@@ -26,7 +26,7 @@ import type { Expr } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
 import { NestedPattern, type NodePattern, type Pattern, type RelationshipPattern } from "./Pattern";
 import { PatternElement } from "./PatternElement";
-import { labelsToString } from "./labels-to-string";
+import { typeToString } from "./labels-to-string";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface PartialPattern extends WithWhere {}
@@ -99,7 +99,7 @@ export class PartialPattern extends PatternElement {
 
     private getTypeStr(env: CypherEnvironment): string {
         if (this.type) {
-            return labelsToString(this.type, env);
+            return typeToString(this.type, env);
         }
         return "";
     }

--- a/src/pattern/Pattern.test.ts
+++ b/src/pattern/Pattern.test.ts
@@ -517,4 +517,16 @@ describe("Patterns", () => {
 
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
+
+    test("Pattern with empty strings as labels and types", () => {
+        const a = new Cypher.Node();
+        const b = new Cypher.Node();
+        const rel = new Cypher.Relationship();
+
+        const query = new TestClause(new Cypher.Pattern(a, { labels: [""] }).related(rel, { type: "" }).to(b));
+        const queryResult = query.build();
+        expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0)-[this1]->(this2)"`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
 });

--- a/src/pattern/labels-to-string.ts
+++ b/src/pattern/labels-to-string.ts
@@ -27,11 +27,9 @@ export function labelsToString(labels: string | string[] | LabelExpr, env: Cyphe
     if (labels instanceof LabelExpr) {
         return addLabelToken(env.config.labelOperator, labels.getCypher(env));
     } else {
-        let escapedLabels = asArray(labels);
+        const shouldEscape = !env.config.unsafeEscapeOptions.disableLabelEscaping;
+        const escapedLabels = shouldEscape ? asArray(labels).map(escapeLabel) : asArray(labels);
 
-        if (!env.config.unsafeEscapeOptions.disableLabelEscaping) {
-            escapedLabels = escapedLabels.map(escapeLabel);
-        }
         return addLabelToken(env.config.labelOperator, ...escapedLabels);
     }
 }
@@ -40,11 +38,8 @@ export function typeToString(type: string | LabelExpr, env: CypherEnvironment): 
     if (type instanceof LabelExpr) {
         return addLabelToken(env.config.labelOperator, type.getCypher(env));
     } else {
-        let escapedType = type;
-
-        if (!env.config.unsafeEscapeOptions.disableRelationshipTypeEscaping) {
-            escapedType = escapeType(escapedType);
-        }
+        const shouldEscape = !env.config.unsafeEscapeOptions.disableRelationshipTypeEscaping;
+        const escapedType = shouldEscape ? escapeType(type) : type;
 
         return addLabelToken(env.config.labelOperator, escapedType);
     }

--- a/src/pattern/labels-to-string.ts
+++ b/src/pattern/labels-to-string.ts
@@ -21,7 +21,7 @@ import type { CypherEnvironment } from "../Environment";
 import { LabelExpr } from "../expressions/labels/label-expressions";
 import { addLabelToken } from "../utils/add-label-token";
 import { asArray } from "../utils/as-array";
-import { escapeLabel } from "../utils/escape";
+import { escapeLabel, escapeType } from "../utils/escape";
 
 export function labelsToString(labels: string | string[] | LabelExpr, env: CypherEnvironment): string {
     if (labels instanceof LabelExpr) {
@@ -31,10 +31,32 @@ export function labelsToString(labels: string | string[] | LabelExpr, env: Cyphe
         }
         return addLabelToken(env.config.labelOperator, labels.getCypher(env));
     } else {
-        const escapedLabels = asArray(labels).map(escapeLabel);
+        let escapedLabels = asArray(labels);
+
+        if (!env.config.unsafeEscapeOptions.disableLabelEscaping) {
+            escapedLabels = escapedLabels.map(escapeLabel);
+        }
         if (escapedLabels.length === 0) {
             return "";
         }
         return addLabelToken(env.config.labelOperator, ...escapedLabels);
+    }
+}
+
+export function typeToString(type: string | LabelExpr, env: CypherEnvironment): string {
+    if (type instanceof LabelExpr) {
+        const labelsStr = type.getCypher(env);
+        if (!labelsStr) {
+            return "";
+        }
+        return addLabelToken(env.config.labelOperator, type.getCypher(env));
+    } else {
+        let escapedType = type;
+
+        if (!env.config.unsafeEscapeOptions.disableRelationshipTypeEscaping) {
+            escapedType = escapeType(escapedType);
+        }
+
+        return addLabelToken(env.config.labelOperator, escapedType);
     }
 }

--- a/src/pattern/labels-to-string.ts
+++ b/src/pattern/labels-to-string.ts
@@ -25,10 +25,6 @@ import { escapeLabel, escapeType } from "../utils/escape";
 
 export function labelsToString(labels: string | string[] | LabelExpr, env: CypherEnvironment): string {
     if (labels instanceof LabelExpr) {
-        const labelsStr = labels.getCypher(env);
-        if (!labelsStr) {
-            return "";
-        }
         return addLabelToken(env.config.labelOperator, labels.getCypher(env));
     } else {
         let escapedLabels = asArray(labels);
@@ -36,19 +32,12 @@ export function labelsToString(labels: string | string[] | LabelExpr, env: Cyphe
         if (!env.config.unsafeEscapeOptions.disableLabelEscaping) {
             escapedLabels = escapedLabels.map(escapeLabel);
         }
-        if (escapedLabels.length === 0) {
-            return "";
-        }
         return addLabelToken(env.config.labelOperator, ...escapedLabels);
     }
 }
 
 export function typeToString(type: string | LabelExpr, env: CypherEnvironment): string {
     if (type instanceof LabelExpr) {
-        const labelsStr = type.getCypher(env);
-        if (!labelsStr) {
-            return "";
-        }
         return addLabelToken(env.config.labelOperator, type.getCypher(env));
     } else {
         let escapedType = type;

--- a/src/references/Variable.ts
+++ b/src/references/Variable.ts
@@ -17,11 +17,11 @@
  * limitations under the License.
  */
 
-import { PropertyRef } from "./PropertyRef";
+import type { CypherEnvironment } from "../Environment";
 import { ListIndex } from "../expressions/list/ListIndex";
 import type { Expr } from "../types";
-import type { CypherEnvironment } from "../Environment";
 import { escapeVariable } from "../utils/escape";
+import { PropertyRef } from "./PropertyRef";
 
 /** Represents a variable
  * @group Variables

--- a/src/utils/stringify-object.test.ts
+++ b/src/utils/stringify-object.test.ts
@@ -39,4 +39,13 @@ describe("stringifyObject", () => {
 
         expect(result).toBe(`{ nobody: expects }`);
     });
+
+    test("escape keys", () => {
+        const result = stringifyObject({
+            ["this name"]: "this",
+            that: `"that"`,
+        });
+
+        expect(result).toBe(`{ \`this name\`: this, that: "that" }`);
+    });
 });

--- a/tests/build-config/unsafe-escape.test.ts
+++ b/tests/build-config/unsafe-escape.test.ts
@@ -164,4 +164,62 @@ RETURN this0 AS \`My Result\`"
 }
 `);
     });
+
+    test("Simple example", () => {
+        const personNode = new Cypher.Node();
+        const movieNode = new Cypher.Node();
+
+        const matchQuery = new Cypher.Match(
+            new Cypher.Pattern(personNode, {
+                labels: ["Person"],
+                properties: {
+                    ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+                },
+            })
+                .related({ type: "ACTED IN" })
+                .to(movieNode, { labels: ["A Movie"] })
+        ).return(personNode);
+
+        const queryResult = matchQuery.build({
+            unsafeEscapeOptions: {
+                disableLabelEscaping: true,
+                disableRelationshipTypeEscaping: true,
+            },
+        });
+
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Person { \`person name\`: \\"Uneak \\\\\\"Seveer\\" })-[:ACTED IN]->(this1:A Movie)
+RETURN this0"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("Manually escaping with utils", () => {
+        const personNode = new Cypher.Node();
+        const movieNode = new Cypher.Node();
+
+        const matchQuery = new Cypher.Match(
+            new Cypher.Pattern(personNode, {
+                labels: [Cypher.utils.escapeLabel("Person")],
+                properties: {
+                    ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+                },
+            })
+                .related({ type: Cypher.utils.escapeType("ACTED IN") })
+                .to(movieNode, { labels: [Cypher.utils.escapeLabel("A Movie")] })
+        ).return(personNode);
+
+        const queryResult = matchQuery.build({
+            unsafeEscapeOptions: {
+                disableLabelEscaping: true,
+                disableRelationshipTypeEscaping: true,
+            },
+        });
+
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Person { \`person name\`: \\"Uneak \\\\\\"Seveer\\" })-[:\`ACTED IN\`]->(this1:\`A Movie\`)
+RETURN this0"
+`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
 });

--- a/tests/build-config/unsafe-escape.test.ts
+++ b/tests/build-config/unsafe-escape.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../../src";
+
+describe("escapeUnsafeLabels", () => {
+    test("Match and update with escaping", () => {
+        const personNode = new Cypher.Node();
+        const movieNode = new Cypher.Node();
+
+        const matchQuery = new Cypher.Match(
+            new Cypher.Pattern(personNode, {
+                labels: ["Person"],
+                properties: {
+                    ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+                },
+            })
+                .related({ type: "ACTED IN" })
+                .to(movieNode, { labels: ["A Movie"] })
+        )
+            .set([personNode.property("person name"), new Cypher.Param("Keanu Reeves")])
+            .return([personNode, new Cypher.NamedVariable("My Result")]);
+
+        const queryResult = matchQuery.build({
+            unsafeEscapeOptions: {
+                disableLabelEscaping: false,
+                disableRelationshipTypeEscaping: false,
+            },
+        });
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Person { \`person name\`: \\"Uneak \\\\\\"Seveer\\" })-[:\`ACTED IN\`]->(this1:\`A Movie\`)
+SET
+    this0.\`person name\` = $param0
+RETURN this0 AS \`My Result\`"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+{
+  "param0": "Keanu Reeves",
+}
+`);
+    });
+
+    test("Match and update without escaping", () => {
+        const personNode = new Cypher.Node();
+        const movieNode = new Cypher.Node();
+
+        const matchQuery = new Cypher.Match(
+            new Cypher.Pattern(personNode, {
+                labels: ["Person"],
+                properties: {
+                    ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+                },
+            })
+                .related({ type: "ACTED IN" })
+                .to(movieNode, { labels: ["A Movie"] })
+        )
+            .set([personNode.property("person name"), new Cypher.Param("Keanu Reeves")])
+            .return([personNode, new Cypher.NamedVariable("My Result")]);
+
+        const queryResult = matchQuery.build({
+            unsafeEscapeOptions: {
+                disableLabelEscaping: true,
+                disableRelationshipTypeEscaping: true,
+            },
+        });
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Person { \`person name\`: \\"Uneak \\\\\\"Seveer\\" })-[:ACTED IN]->(this1:A Movie)
+SET
+    this0.\`person name\` = $param0
+RETURN this0 AS \`My Result\`"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+{
+  "param0": "Keanu Reeves",
+}
+`);
+    });
+
+    test("Match and update without escaping labels", () => {
+        const personNode = new Cypher.Node();
+        const movieNode = new Cypher.Node();
+
+        const matchQuery = new Cypher.Match(
+            new Cypher.Pattern(personNode, {
+                labels: ["Person"],
+                properties: {
+                    ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+                },
+            })
+                .related({ type: "ACTED IN" })
+                .to(movieNode, { labels: ["A Movie"] })
+        )
+            .set([personNode.property("person name"), new Cypher.Param("Keanu Reeves")])
+            .return([personNode, new Cypher.NamedVariable("My Result")]);
+
+        const queryResult = matchQuery.build({
+            unsafeEscapeOptions: {
+                disableLabelEscaping: true,
+            },
+        });
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Person { \`person name\`: \\"Uneak \\\\\\"Seveer\\" })-[:\`ACTED IN\`]->(this1:A Movie)
+SET
+    this0.\`person name\` = $param0
+RETURN this0 AS \`My Result\`"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+{
+  "param0": "Keanu Reeves",
+}
+`);
+    });
+    test("Match and update without escaping types", () => {
+        const personNode = new Cypher.Node();
+        const movieNode = new Cypher.Node();
+
+        const matchQuery = new Cypher.Match(
+            new Cypher.Pattern(personNode, {
+                labels: ["Person"],
+                properties: {
+                    ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
+                },
+            })
+                .related({ type: "ACTED IN" })
+                .to(movieNode, { labels: ["A Movie"] })
+        )
+            .set([personNode.property("person name"), new Cypher.Param("Keanu Reeves")])
+            .return([personNode, new Cypher.NamedVariable("My Result")]);
+
+        const queryResult = matchQuery.build({
+            unsafeEscapeOptions: {
+                disableRelationshipTypeEscaping: true,
+            },
+        });
+        expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0:Person { \`person name\`: \\"Uneak \\\\\\"Seveer\\" })-[:ACTED IN]->(this1:\`A Movie\`)
+SET
+    this0.\`person name\` = $param0
+RETURN this0 AS \`My Result\`"
+`);
+
+        expect(queryResult.params).toMatchInlineSnapshot(`
+{
+  "param0": "Keanu Reeves",
+}
+`);
+    });
+});


### PR DESCRIPTION
New options to disable automatic escaping of labels and relationship types have been added to the `.build` method on clauses, inside the new object `unsafeEscapeOptions`:

- `disableLabelEscaping` (defaults to `false`): If set to true, node labels will not be escaped if unsafe.
- `disableRelationshipTypeEscaping` (defaults to `false`): If set to true, relationship types will not be escaped if unsafe

For example:

```js
const personNode = new Cypher.Node();
const movieNode = new Cypher.Node();

const matchQuery = new Cypher.Match(
    new Cypher.Pattern(personNode, {
        labels: ["Person"],
        properties: {
            ["person name"]: new Cypher.Literal(`Uneak "Seveer`),
        },
    })
        .related({ type: "ACTED IN" })
        .to(movieNode, { labels: ["A Movie"] })
).return(personNode);

const queryResult = matchQuery.build({
    unsafeEscapeOptions: {
        disableLabelEscaping: true,
        disableRelationshipTypeEscaping: true,
    },
});
```

This query will generate the following (invalid) Cypher:

```
MATCH (this0:Person { `person name`: "Uneak \"Seveer" })-[:ACTED IN]->(this1:A Movie)
RETURN this0
```

Instead of the default (safe) Cypher:

```cypher
MATCH (this0:Person { `person name`: "Uneak \"Seveer" })-[:`ACTED IN`]->(this1:`A Movie`)
RETURN this0
```

**WARNING:**: Changing these options may lead to code injection and unsafe Cypher.