### PR TITLE
Remove duplicate testing in workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x, lts/*, latest]
+        node-version: [16.x, latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -23,6 +23,24 @@ jobs:
       - run: npm install
       - run: npm run build --if-present
       - run: npm test
+
+  test-lts-with-coverage:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js LTS
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test -- --coverage
+      - name: Upload code coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage/lcov.info
 
   examples:
     runs-on: ubuntu-latest
@@ -53,23 +71,3 @@ jobs:
               exit 1
             fi
           done
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs:
-      - test
-      - examples
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install dependencies
-        run: npm install
-      - name: Coverage
-        run: npm test -- --coverage
-
-      - name: Upload code coverage
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage
-          path: coverage/lcov.info


### PR DESCRIPTION
Removes duplicate test on LTS (in a normal test and for coverage). This reduces the number of jobs and the overall time to finish the pipeline, as now coverage is done in parallel to the rest of tests