### PR TITLE
Rename disableLabelEscaping

### DIFF
--- a/.changeset/wide-breads-help.md
+++ b/.changeset/wide-breads-help.md
@@ -1,0 +1,14 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Rename `disableLabelEscaping` to `disableNodeLabelEscaping` in `unsafeEscapeOptions`:
+
+```js
+const queryResult = matchQuery.build({
+    unsafeEscapeOptions: {
+        disableNodeLabelEscaping: true,
+        disableRelationshipTypeEscaping: true,
+    },
+});
+```

--- a/docs/modules/ROOT/pages/how-to/customize-cypher.adoc
+++ b/docs/modules/ROOT/pages/how-to/customize-cypher.adoc
@@ -357,7 +357,7 @@ Changing these options may lead to code injection and unsafe Cypher.
 
 Cypher Builder automatically escapes unsafe strings that could lead to code injection. This behavior can be configured using the `unsafeEscapeOptions` parameter in the `.build` method of clauses:
 
-- `disableLabelEscaping` (defaults to `false`): If set to `true`, node labels will not be escaped, even if unsafe.
+- `disableNodeLabelEscaping` (defaults to `false`): If set to `true`, node labels will not be escaped, even if unsafe.
 - `disableRelationshipTypeEscaping` (defaults to `false`): If set to `true`, relationship types will not be escaped, even if unsafe.
 
 For example:
@@ -380,7 +380,7 @@ const matchQuery = new Cypher.Match(
 
 const queryResult = matchQuery.build({
     unsafeEscapeOptions: {
-        disableLabelEscaping: true,
+        disableNodeLabelEscaping: true,
         disableRelationshipTypeEscaping: true,
     },
 });
@@ -430,7 +430,7 @@ const matchQuery = new Cypher.Match(
 
 const queryResult = matchQuery.build({
     unsafeEscapeOptions: {
-        disableLabelEscaping: true,
+        disableNodeLabelEscaping: true,
         disableRelationshipTypeEscaping: true,
     },
 });

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -61,7 +61,7 @@ export type BuildConfig = Partial<{
          *
          * **WARNING**: Disabling label escaping may lead to code injection and unsafe Cypher.
          */
-        disableLabelEscaping: boolean;
+        disableNodeLabelEscaping: boolean;
         /** Disables automatic escaping of relationship types.
          *
          * If disabled, any types passed should be properly escaped with `utils.escapeType`.

--- a/src/pattern/labels-to-string.ts
+++ b/src/pattern/labels-to-string.ts
@@ -27,7 +27,7 @@ export function labelsToString(labels: string | string[] | LabelExpr, env: Cyphe
     if (labels instanceof LabelExpr) {
         return addLabelToken(env.config.labelOperator, labels.getCypher(env));
     } else {
-        const shouldEscape = !env.config.unsafeEscapeOptions.disableLabelEscaping;
+        const shouldEscape = !env.config.unsafeEscapeOptions.disableNodeLabelEscaping;
         const escapedLabels = shouldEscape ? asArray(labels).map(escapeLabel) : asArray(labels);
 
         return addLabelToken(env.config.labelOperator, ...escapedLabels);

--- a/tests/build-config/unsafe-escape.test.ts
+++ b/tests/build-config/unsafe-escape.test.ts
@@ -39,7 +39,7 @@ describe("escapeUnsafeLabels", () => {
 
         const queryResult = matchQuery.build({
             unsafeEscapeOptions: {
-                disableLabelEscaping: false,
+                disableNodeLabelEscaping: false,
                 disableRelationshipTypeEscaping: false,
             },
         });
@@ -76,7 +76,7 @@ RETURN this0 AS \`My Result\`"
 
         const queryResult = matchQuery.build({
             unsafeEscapeOptions: {
-                disableLabelEscaping: true,
+                disableNodeLabelEscaping: true,
                 disableRelationshipTypeEscaping: true,
             },
         });
@@ -113,7 +113,7 @@ RETURN this0 AS \`My Result\`"
 
         const queryResult = matchQuery.build({
             unsafeEscapeOptions: {
-                disableLabelEscaping: true,
+                disableNodeLabelEscaping: true,
             },
         });
         expect(queryResult.cypher).toMatchInlineSnapshot(`
@@ -182,7 +182,7 @@ RETURN this0 AS \`My Result\`"
 
         const queryResult = matchQuery.build({
             unsafeEscapeOptions: {
-                disableLabelEscaping: true,
+                disableNodeLabelEscaping: true,
                 disableRelationshipTypeEscaping: true,
             },
         });
@@ -211,7 +211,7 @@ RETURN this0"
 
         const queryResult = matchQuery.build({
             unsafeEscapeOptions: {
-                disableLabelEscaping: true,
+                disableNodeLabelEscaping: true,
                 disableRelationshipTypeEscaping: true,
             },
         });


### PR DESCRIPTION

Rename `disableLabelEscaping` to `disableNodeLabelEscaping` in `unsafeEscapeOptions`:

```js
const queryResult = matchQuery.build({
    unsafeEscapeOptions: {
        disableNodeLabelEscaping: true,
        disableRelationshipTypeEscaping: true,
    },
});
```