### PR TITLE
Add concat operator

### DIFF
--- a/.changeset/stale-lands-repeat.md
+++ b/.changeset/stale-lands-repeat.md
@@ -1,0 +1,15 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add support for concatenation operator (`||`) with `Cypher.concat`
+
+```js
+Cypher.concat(new Cypher.Literal("Hello"), new Cypher.Literal("World!"));
+```
+
+```cypher
+("Hello" || "World!")
+```
+
+This is functionally equivalent to `Cypher.plus` with uses the operator `+` instead.

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -39,7 +39,7 @@ export { QuantifiedPath } from "./pattern/quantified-patterns/QuantifiedPath";
 export { type QuantifiedPattern, type Quantifier } from "./pattern/quantified-patterns/QuantifiedPattern";
 
 // Variables and references
-export { Literal, CypherNull as Null, CypherFalse as false, CypherTrue as true } from "./references/Literal";
+export { CypherFalse as false, Literal, CypherNull as Null, CypherTrue as true } from "./references/Literal";
 export { NamedNode, NodeRef as Node } from "./references/NodeRef";
 export { NamedParam, Param } from "./references/Param";
 export { NamedPathVariable, PathVariable } from "./references/Path";
@@ -49,7 +49,7 @@ export { NamedVariable, Variable } from "./references/Variable";
 
 // Expressions
 export { Case, type When } from "./expressions/Case";
-export { CypherTypes as TYPE, isNotType, isType, type IsType, type ListType } from "./expressions/IsType";
+export { isNotType, isType, CypherTypes as TYPE, type IsType, type ListType } from "./expressions/IsType";
 
 // Subquery Expressions
 export { Collect } from "./expressions/subquery/Collect";
@@ -93,6 +93,7 @@ export {
     startsWith,
     type ComparisonOp,
 } from "./expressions/operations/comparison";
+export { concat, ConcatOp } from "./expressions/operations/concat";
 export { divide, minus, mod, multiply, plus, pow, type MathOp } from "./expressions/operations/math";
 
 // --Functions
@@ -114,7 +115,6 @@ export * as graph from "./expressions/functions/graph";
 export * from "./expressions/functions/list";
 export { file, linenumber } from "./expressions/functions/load-csv";
 export {
-    ROUND_PRECISION_MODE,
     abs,
     acos,
     asin,
@@ -135,6 +135,7 @@ export {
     radians,
     rand,
     round,
+    ROUND_PRECISION_MODE,
     sign,
     sin,
     sqrt,
@@ -146,12 +147,12 @@ export * from "./expressions/functions/scalar";
 export * from "./expressions/functions/spatial";
 export * from "./expressions/functions/string";
 export {
-    TemporalUnit,
     cypherDate as date,
     cypherDatetime as datetime,
     duration,
     cypherLocalDatetime as localdatetime,
     cypherLocalTime as localtime,
+    TemporalUnit,
     cypherTime as time,
 } from "./expressions/functions/temporal";
 

--- a/src/expressions/operations/concat.test.ts
+++ b/src/expressions/operations/concat.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../..";
+import { TestClause } from "../../utils/TestClause";
+
+describe("concat operators", () => {
+    test("concatenating strings", () => {
+        const concat = Cypher.concat(new Cypher.Literal("Hello"), new Cypher.Literal("World!"));
+        const { cypher } = new TestClause(concat).build();
+        expect(cypher).toMatchInlineSnapshot(`"(\\"Hello\\" || \\"World!\\")"`);
+    });
+    test("concatenating multiple strings with params", () => {
+        const concat = Cypher.concat(
+            new Cypher.Literal("Hello"),
+            new Cypher.Literal("World!"),
+            new Cypher.Param("Thanks for all the fish")
+        );
+        const { cypher, params } = new TestClause(concat).build();
+        expect(cypher).toMatchInlineSnapshot(`"(\\"Hello\\" || \\"World!\\" || $param0)"`);
+        expect(params).toMatchInlineSnapshot(`
+{
+  "param0": "Thanks for all the fish",
+}
+`);
+    });
+
+    test("concatenating strings as part of an expression", () => {
+        const node = new Cypher.Node();
+        const matchSet = new Cypher.Match(new Cypher.Pattern(node)).set([
+            node.property("greeting"),
+            Cypher.concat(new Cypher.Literal("Hello "), node.property("name")),
+        ]);
+        const { cypher } = new TestClause(matchSet).build();
+        expect(cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+SET
+    this0.greeting = (\\"Hello \\" || this0.name)"
+`);
+    });
+});

--- a/src/expressions/operations/concat.ts
+++ b/src/expressions/operations/concat.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CypherASTNode } from "../../CypherASTNode";
+import type { CypherEnvironment } from "../../Environment";
+import type { Expr } from "../../types";
+
+const ConcatOperator = "||";
+
+export class ConcatOp extends CypherASTNode {
+    private readonly exprs: Expr[];
+
+    /** @internal */
+    constructor(exprs: Expr[]) {
+        super();
+        this.exprs = exprs;
+    }
+
+    /**
+     * @hidden
+     */
+    public getCypher(env: CypherEnvironment): string {
+        const exprs = this.exprs.map((e) => e.getCypher(env));
+
+        const operatorStr = ` ${ConcatOperator} `;
+        return `(${exprs.join(operatorStr)})`;
+    }
+}
+
+/** Concat (||) operator. This operator may be used for concatenating strings. For concatenating Cypher builder clauses use `utils.concat`
+ * @see {@link https://neo4j.com/docs/cypher-manual/current/syntax/operators/#syntax-concatenating-two-strings-doublebar | Cypher Documentation}
+ * @group Operators
+ * @category String
+ */
+export function concat(leftExpr: Expr, rightExpr: Expr): ConcatOp;
+export function concat(...exprs: Expr[]): ConcatOp;
+export function concat(...exprs: Expr[]): ConcatOp {
+    return new ConcatOp(exprs);
+}

--- a/src/expressions/operations/math.test.ts
+++ b/src/expressions/operations/math.test.ts
@@ -52,6 +52,12 @@ describe("math operators", () => {
         expect(cypher).toMatchInlineSnapshot(`"(10 + 3)"`);
     });
 
+    test("plus for concatenating strings", () => {
+        const concatPlus = Cypher.plus(new Cypher.Literal("Hello"), new Cypher.Literal("World!"));
+        const { cypher } = new TestClause(concatPlus).build();
+        expect(cypher).toMatchInlineSnapshot(`"(\\"Hello\\" + \\"World!\\")"`);
+    });
+
     test("minus", () => {
         const subtract = Cypher.minus(new Cypher.Literal(10), new Cypher.Literal(3));
         const { cypher } = new TestClause(subtract).build();

--- a/src/expressions/operations/math.ts
+++ b/src/expressions/operations/math.ts
@@ -51,7 +51,7 @@ function createOp(op: MathOperator, exprs: Expr[]): MathOp {
 
 /** Plus (+) operator. This operator may be used for addition operations between numbers or for string concatenation.
  * @see {@link https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical | Cypher Documentation}
- * @see [String Concatenation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#syntax-concatenating-two-strings)
+ * @see {@link https://neo4j.com/docs/cypher-manual/current/syntax/operators/#syntax-concatenating-two-strings | String Concatenation}
  * @group Operators
  * @category Math
  */

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import type { ConcatOp } from ".";
 import type { CypherEnvironment } from "./Environment";
 import type { Raw } from "./clauses/Raw";
 import type { Case } from "./expressions/Case";
@@ -40,7 +41,7 @@ import type { Literal } from "./references/Literal";
 import type { PropertyRef } from "./references/PropertyRef";
 import type { Variable } from "./references/Variable";
 
-export type Operation = BooleanOp | ComparisonOp | MathOp;
+export type Operation = BooleanOp | ComparisonOp | MathOp | ConcatOp;
 
 /** Represents a Cypher Expression
  *  @see {@link https://neo4j.com/docs/cypher-manual/current/syntax/expressions/ | Cypher Documentation}


### PR DESCRIPTION
Add support for concatenation operator (`||`) with `Cypher.concat`

```js
Cypher.concat(new Cypher.Literal("Hello"), new Cypher.Literal("World!"));
```

```cypher
("Hello" || "World!")
```

This is functionally equivalent to `Cypher.plus` with uses the operator `+` instead.