### PR TITLE
Explicitly exports used types in public api

### DIFF
--- a/.changeset/wild-eyes-play.md
+++ b/.changeset/wild-eyes-play.md
@@ -1,0 +1,16 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Explicitly exports some types that were used or returned by public functions and methods:
+
+- `CallInTransactionOptions`
+- `ForeachClauses`
+- `PartialPattern`
+- `LiteralValue`
+- `ListIndex`
+- `DeleteInput`
+- `NodePatternOptions`
+- `RelationshipPatternOptions`
+
+Some methods and internal types have also been changed to better reflect the exposed types and avoid using internal types in public API

--- a/.changeset/wild-eyes-play.md
+++ b/.changeset/wild-eyes-play.md
@@ -12,5 +12,6 @@ Explicitly exports some types that were used or returned by public functions and
 - `DeleteInput`
 - `NodePatternOptions`
 - `RelationshipPatternOptions`
+- `YieldProjectionColumn`
 
 Some methods and internal types have also been changed to better reflect the exposed types and avoid using internal types in public API

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,6 +1,6 @@
 # Development
 
-- `npm test` to run cypher builder tests
+- `npm test` to run cypher builder tests. Most tests are located next to the code that are testing as a `.test.ts` file
 - `npm run build` to compile cypher builder library
 - `npm run docs` to generate the API reference docs
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "neo4j-driver": "^5.26.0",
         "prettier": "^3.4.1",
         "ts-jest": "^29.2.5",
-        "typedoc": "^0.27.7",
+        "typedoc": "^0.27.9",
         "typescript": "^5.6.3"
     }
 }

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -179,7 +179,7 @@ export type { PredicateFunction } from "./expressions/functions/predicate";
 export type { HasLabel } from "./expressions/HasLabel";
 export type { LabelExpr, LabelOperator } from "./expressions/labels/label-expressions";
 export type { PathAssign } from "./pattern/PathAssign";
-export type { Yield } from "./procedures/Yield";
+export type { Yield, YieldProjectionColumn } from "./procedures/Yield";
 export type { Label } from "./references/Label";
 export type { CypherResult, Expr, NormalizationType, Operation, Predicate } from "./types";
 export type { InputArgument } from "./utils/normalize-variable";

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -18,10 +18,10 @@
  */
 
 // Clauses
-export { Call, OptionalCall } from "./clauses/Call";
+export { Call, OptionalCall, type CallInTransactionOptions } from "./clauses/Call";
 export { Create } from "./clauses/Create";
 export { Finish } from "./clauses/Finish";
-export { Foreach } from "./clauses/Foreach";
+export { Foreach, type ForeachClauses } from "./clauses/Foreach";
 export { LoadCSV } from "./clauses/LoadCSV";
 export { Match, OptionalMatch } from "./clauses/Match";
 export { Merge } from "./clauses/Merge";
@@ -34,12 +34,19 @@ export { With } from "./clauses/With";
 
 // Patterns
 export { labelExpr } from "./expressions/labels/label-expressions";
-export { Pattern } from "./pattern/Pattern";
+export type { PartialPattern } from "./pattern/PartialPattern";
+export { Pattern, type NodePatternOptions, type RelationshipPatternOptions } from "./pattern/Pattern";
 export { QuantifiedPath } from "./pattern/quantified-patterns/QuantifiedPath";
-export { type QuantifiedPattern, type Quantifier } from "./pattern/quantified-patterns/QuantifiedPattern";
+export type { QuantifiedPattern, Quantifier } from "./pattern/quantified-patterns/QuantifiedPattern";
 
 // Variables and references
-export { CypherFalse as false, Literal, CypherNull as Null, CypherTrue as true } from "./references/Literal";
+export {
+    CypherFalse as false,
+    Literal,
+    CypherNull as Null,
+    CypherTrue as true,
+    type LiteralValue,
+} from "./references/Literal";
 export { NamedNode, NodeRef as Node } from "./references/NodeRef";
 export { NamedParam, Param } from "./references/Param";
 export { NamedPathVariable, PathVariable } from "./references/Path";
@@ -67,6 +74,7 @@ export * as vector from "./namespaces/vector/vector";
 // --Lists
 export { ListComprehension } from "./expressions/list/ListComprehension";
 export { ListExpr as List } from "./expressions/list/ListExpr";
+export type { ListIndex } from "./expressions/list/ListIndex";
 export { PatternComprehension } from "./expressions/list/PatternComprehension";
 
 // --Map
@@ -161,6 +169,7 @@ export { CypherProcedure as Procedure, VoidCypherProcedure as VoidProcedure } fr
 
 // Types
 export type { BuildConfig, Clause } from "./clauses/Clause";
+export type { DeleteInput } from "./clauses/sub-clauses/Delete";
 export type { Order } from "./clauses/sub-clauses/OrderBy";
 export type { ProjectionColumn } from "./clauses/sub-clauses/Projection";
 export type { SetParam } from "./clauses/sub-clauses/Set";

--- a/src/Environment.ts
+++ b/src/Environment.ts
@@ -61,7 +61,7 @@ export class CypherEnvironment {
         };
     }
 
-    public getReferenceId(reference: Variable | NamedReference): string {
+    public getReferenceId(reference: Variable): string {
         if (this.isNamedReference(reference)) return reference.id; // Overrides ids for compatibility reasons
         const id = this.references.get(reference);
         if (!id) {
@@ -117,8 +117,7 @@ export class CypherEnvironment {
         return varId;
     }
 
-    private isNamedReference(ref: Variable | NamedReference): ref is NamedReference {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-        return Boolean((ref as any).id);
+    private isNamedReference(ref: Variable): ref is NamedReference {
+        return "id" in ref;
     }
 }

--- a/src/clauses/Call.ts
+++ b/src/clauses/Call.ts
@@ -48,7 +48,7 @@ export interface Call
         WithMerge,
         WithOrder {}
 
-type InTransactionConfig = {
+export type CallInTransactionOptions = {
     ofRows?: number;
     onError?: "continue" | "break" | "fail";
     concurrentTransactions?: number;
@@ -62,7 +62,7 @@ type InTransactionConfig = {
 export class Call extends Clause {
     private readonly subquery: CypherASTNode;
     private _importWith?: ImportWith;
-    private inTransactionsConfig?: InTransactionConfig;
+    private inTransactionsConfig?: CallInTransactionOptions;
     private readonly variableScope?: Variable[] | "*";
     private _optional: boolean = false;
 
@@ -91,7 +91,7 @@ export class Call extends Clause {
         return this;
     }
 
-    public inTransactions(config: InTransactionConfig = {}): this {
+    public inTransactions(config: CallInTransactionOptions = {}): this {
         this.inTransactionsConfig = config;
         return this;
     }

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -79,13 +79,9 @@ export abstract class Clause extends CypherASTNode {
     protected nextClause: Clause | undefined;
 
     /** Compiles a clause into Cypher and params */
-    public build({
-        prefix,
-        extraParams = {},
-        labelOperator = ":",
-        cypherVersion,
-        unsafeEscapeOptions = {},
-    }: BuildConfig = {}): CypherResult {
+    public build(config?: BuildConfig): CypherResult {
+        const { prefix, extraParams = {}, labelOperator = ":", cypherVersion, unsafeEscapeOptions = {} } = config ?? {};
+
         if (this.isRoot) {
             const env = this.getEnv(prefix, {
                 labelOperator,

--- a/src/clauses/Foreach.ts
+++ b/src/clauses/Foreach.ts
@@ -31,14 +31,11 @@ import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
 import { WithSetRemove } from "./mixins/sub-clauses/WithSetRemove";
-import type { DeleteClause } from "./sub-clauses/Delete";
-import type { RemoveClause } from "./sub-clauses/Remove";
-import type { SetClause } from "./sub-clauses/Set";
 import { mixin } from "./utils/mixin";
 
 export interface Foreach extends WithWith, WithReturn, WithSetRemove, WithDelete, WithCreate, WithMerge {}
 
-type ForeachClauses = Foreach | SetClause | RemoveClause | Create | Merge | DeleteClause;
+export type ForeachClauses = Foreach | Create | Merge;
 
 /**
  * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/foreach/ | Cypher Documentation}

--- a/src/clauses/Raw.ts
+++ b/src/clauses/Raw.ts
@@ -31,7 +31,9 @@ type RawCypherCallback = (context: RawCypherContext) => [string, Record<string, 
 export class Raw extends Clause {
     private readonly callback: RawCypherCallback;
 
-    constructor(callback: RawCypherCallback | string) {
+    constructor(
+        callback: ((context: RawCypherContext) => [string, Record<string, unknown>] | string | undefined) | string
+    ) {
         super();
         if (typeof callback === "string") {
             this.callback = this.stringToCallback(callback);
@@ -62,6 +64,7 @@ export class Raw extends Clause {
 export class RawCypherContext {
     private readonly env: CypherEnvironment;
 
+    /** @internal */
     constructor(env: CypherEnvironment) {
         this.env = env;
     }

--- a/src/clauses/mixins/sub-clauses/WithWhere.ts
+++ b/src/clauses/mixins/sub-clauses/WithWhere.ts
@@ -28,7 +28,7 @@ import type { Predicate } from "../../../types";
 import { Where } from "../../sub-clauses/Where";
 import { Mixin } from "../Mixin";
 
-export type VariableLike = Variable | Literal | PropertyRef;
+type VariableLike = Variable | Literal | PropertyRef;
 
 export abstract class WithWhere extends Mixin {
     protected whereSubClause: Where | undefined;

--- a/src/expressions/IsType.ts
+++ b/src/expressions/IsType.ts
@@ -109,6 +109,7 @@ export class ListType {
         return this;
     }
 
+    /** @internal */
     public getCypher(env: CypherEnvironment): string {
         // Note that all types must be nullable or non nullable
         const notNullStr = this._notNull ? " NOT NULL" : "";
@@ -143,6 +144,7 @@ export class IsType extends CypherASTNode {
         return this;
     }
 
+    /** @internal */
     public getCypher(env: CypherEnvironment): string {
         const exprCypher = this.expr.getCypher(env);
         const isStr = this.not ? "IS NOT" : "IS";

--- a/src/expressions/labels/label-expressions.ts
+++ b/src/expressions/labels/label-expressions.ts
@@ -131,7 +131,7 @@ function labelNot(label: string | LabelExpr): LabelExpr {
  * @group Expressions
  * @category Operators
  */
-const wildcard = new WildcardLabelExpr();
+const wildcard: LabelExpr = new WildcardLabelExpr();
 
 export const labelExpr = {
     and: labelAnd,

--- a/src/pattern/PartialPattern.ts
+++ b/src/pattern/PartialPattern.ts
@@ -24,8 +24,13 @@ import type { LabelExpr } from "../expressions/labels/label-expressions";
 import type { Variable } from "../references/Variable";
 import type { Expr } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
-import type { LengthOption, RelationshipPatternOptions } from "./Pattern";
-import { NestedPattern, type NodePatternOptions, type Pattern } from "./Pattern";
+import {
+    NestedPattern,
+    type LengthOption,
+    type NodePatternOptions,
+    type Pattern,
+    type RelationshipPatternOptions,
+} from "./Pattern";
 import { PatternElement } from "./PatternElement";
 import { typeToString } from "./labels-to-string";
 

--- a/src/pattern/PartialPattern.ts
+++ b/src/pattern/PartialPattern.ts
@@ -24,34 +24,28 @@ import type { LabelExpr } from "../expressions/labels/label-expressions";
 import type { Variable } from "../references/Variable";
 import type { Expr } from "../types";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
-import { NestedPattern, type NodePattern, type Pattern, type RelationshipPattern } from "./Pattern";
+import type { LengthOption, RelationshipPatternOptions } from "./Pattern";
+import { NestedPattern, type NodePatternOptions, type Pattern } from "./Pattern";
 import { PatternElement } from "./PatternElement";
 import { typeToString } from "./labels-to-string";
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface PartialPattern extends WithWhere {}
 
-export type LengthOption =
-    | number
-    | "*"
-    | { min: number; max?: number }
-    | { min?: number; max: number }
-    | { min: number; max: number };
-
-/** Partial pattern, cannot be used until connected to a node
+/** Partial pattern, cannot be used until connected to a node with {@link to}
  * @group Patterns
  */
 
 @mixin(WithWhere)
 export class PartialPattern extends PatternElement {
-    private readonly length: LengthOption | undefined;
+    private readonly length: LengthOption;
     private readonly direction: "left" | "right" | "undirected";
     private readonly previous: Pattern;
     private readonly properties: Record<string, Expr> | undefined;
 
     private readonly type: string | LabelExpr | undefined;
 
-    constructor(variable: Variable | undefined, options: RelationshipPattern, previous: Pattern) {
+    constructor(variable: Variable | undefined, options: RelationshipPatternOptions, previous: Pattern) {
         super(variable);
 
         this.type = options.type;
@@ -61,9 +55,10 @@ export class PartialPattern extends PatternElement {
         this.length = options.length;
     }
 
-    public to(node: Variable | undefined, options?: NodePattern): Pattern;
-    public to(nodeConfig?: NodePattern): Pattern;
-    public to(node?: Variable | NodePattern, options?: NodePattern): Pattern {
+    /** Connects pattern to a target Node */
+    public to(node: Variable | undefined, options?: NodePatternOptions): Pattern;
+    public to(nodeConfig?: NodePatternOptions): Pattern;
+    public to(node?: Variable | NodePatternOptions, options?: NodePatternOptions): Pattern {
         return new NestedPattern(node, options, this);
     }
 

--- a/src/procedures/Yield.ts
+++ b/src/procedures/Yield.ts
@@ -101,7 +101,7 @@ export class Yield<T extends string = string> extends Clause {
     }
 }
 
-export class YieldProjection extends Projection {
+class YieldProjection extends Projection {
     constructor(columns: Array<YieldProjectionColumn<string>>) {
         super([]);
         this.addYieldColumns(columns);

--- a/src/references/Literal.ts
+++ b/src/references/Literal.ts
@@ -20,7 +20,7 @@
 import type { CypherCompilable } from "../types";
 import { escapeLiteralString } from "../utils/escape";
 
-type LiteralValue = string | number | boolean | null | Array<LiteralValue>;
+export type LiteralValue = string | number | boolean | null | Array<LiteralValue>;
 
 /** Represents a literal value
  * @group Variables

--- a/src/references/Variable.ts
+++ b/src/references/Variable.ts
@@ -53,6 +53,7 @@ export class Variable {
     }
 }
 
+/** @internal */
 export interface NamedReference extends Variable {
     readonly id: string;
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -18,5 +18,5 @@
     "validation": {
         "invalidLink": true
     },
-    "intentionallyNotExported": ["CypherCompilable"]
+    "intentionallyNotExported": ["CypherCompilable", "NamedReference"]
 }


### PR DESCRIPTION
This PR partially fixes #466 


Explicitly exports some types that were used or returned by public functions and methods:

- `CallInTransactionOptions`
- `ForeachClauses`
- `PartialPattern`
- `LiteralValue`
- `ListIndex`
- `DeleteInput`
- `NodePatternOptions`
- `RelationshipPatternOptions`

Some methods and internal types have also been changed to better reflect the exposed types and avoid using internal types in public API