### PR TITLE
Deprecate IsType in favor of IsTypeExpr

### DIFF
--- a/.changeset/fancy-chicken-post.md
+++ b/.changeset/fancy-chicken-post.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecate type `IsType` in favor of `IsTypeExpr`. This is to avoid confusion with the function `isType` which returns that type.

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -39,7 +39,7 @@ export { QuantifiedPath } from "./pattern/quantified-patterns/QuantifiedPath";
 export { type QuantifiedPattern, type Quantifier } from "./pattern/quantified-patterns/QuantifiedPattern";
 
 // Variables and references
-export { Literal, CypherNull as Null, CypherFalse as false, CypherTrue as true } from "./references/Literal";
+export { CypherFalse as false, Literal, CypherNull as Null, CypherTrue as true } from "./references/Literal";
 export { NamedNode, NodeRef as Node } from "./references/NodeRef";
 export { NamedParam, Param } from "./references/Param";
 export { NamedPathVariable, PathVariable } from "./references/Path";
@@ -49,7 +49,14 @@ export { NamedVariable, Variable } from "./references/Variable";
 
 // Expressions
 export { Case, type When } from "./expressions/Case";
-export { CypherTypes as TYPE, isNotType, isType, type IsType, type ListType } from "./expressions/IsType";
+export {
+    isNotType,
+    isType,
+    CypherTypes as TYPE,
+    type IsType,
+    type IsTypeExpr,
+    type ListType,
+} from "./expressions/IsType";
 
 // Subquery Expressions
 export { Collect } from "./expressions/subquery/Collect";
@@ -114,7 +121,6 @@ export * as graph from "./expressions/functions/graph";
 export * from "./expressions/functions/list";
 export { file, linenumber } from "./expressions/functions/load-csv";
 export {
-    ROUND_PRECISION_MODE,
     abs,
     acos,
     asin,
@@ -135,6 +141,7 @@ export {
     radians,
     rand,
     round,
+    ROUND_PRECISION_MODE,
     sign,
     sin,
     sqrt,
@@ -146,12 +153,12 @@ export * from "./expressions/functions/scalar";
 export * from "./expressions/functions/spatial";
 export * from "./expressions/functions/string";
 export {
-    TemporalUnit,
     cypherDate as date,
     cypherDatetime as datetime,
     duration,
     cypherLocalDatetime as localdatetime,
     cypherLocalTime as localtime,
+    TemporalUnit,
     cypherTime as time,
 } from "./expressions/functions/temporal";
 

--- a/src/expressions/IsType.ts
+++ b/src/expressions/IsType.ts
@@ -79,8 +79,8 @@ export const CypherTypes = {
  * val IS :: INTEGER
  * ```
  */
-export function isType(expr: Expr, type: Type | Type[]): IsType {
-    return new IsType(expr, asArray(type));
+export function isType(expr: Expr, type: Type | Type[]): IsTypeExpr {
+    return new IsTypeExpr(expr, asArray(type));
 }
 
 /**
@@ -91,8 +91,8 @@ export function isType(expr: Expr, type: Type | Type[]): IsType {
  * val IS NOT :: INTEGER
  * ```
  */
-export function isNotType(expr: Expr, type: Type | Type[]): IsType {
-    return new IsType(expr, asArray(type), true);
+export function isNotType(expr: Expr, type: Type | Type[]): IsTypeExpr {
+    return new IsTypeExpr(expr, asArray(type), true);
 }
 
 export class ListType {
@@ -124,7 +124,10 @@ export class ListType {
     }
 }
 
-export class IsType extends CypherASTNode {
+/** @deprecated Use {@link IsTypeExpr} instead */
+export type IsType = IsTypeExpr;
+
+export class IsTypeExpr extends CypherASTNode {
     private readonly expr: Expr;
     private readonly types: Type[];
     private readonly not: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,7 +21,7 @@ import type { CypherEnvironment } from "./Environment";
 import type { Raw } from "./clauses/Raw";
 import type { Case } from "./expressions/Case";
 import type { HasLabel } from "./expressions/HasLabel";
-import type { IsType } from "./expressions/IsType";
+import type { IsTypeExpr } from "./expressions/IsType";
 import type { CypherFunction } from "./expressions/functions/CypherFunctions";
 import type { PredicateFunction } from "./expressions/functions/predicate";
 import type { ListComprehension } from "./expressions/list/ListComprehension";
@@ -72,7 +72,7 @@ export type Predicate =
     | Literal<boolean>
     | Case
     | HasLabel
-    | IsType;
+    | IsTypeExpr;
 
 export type CypherResult = {
     cypher: string;


### PR DESCRIPTION
Maybe it should be discussed if this is needed at all

Deprecate type `IsType` in favor of `IsTypeExpr`. This is to avoid confusion with the function `isType` which returns that type.