### PR TITLE
Add since tag in tsdoc comments

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "neo4j-driver": "^5.26.0",
         "prettier": "^3.4.1",
         "ts-jest": "^29.2.5",
-        "typedoc": "^0.28.0",
+        "typedoc": "^0.28.1",
         "typescript": "^5.6.3"
     }
 }

--- a/src/clauses/Call.ts
+++ b/src/clauses/Call.ts
@@ -99,7 +99,7 @@ export class Call extends Clause {
 
     /** Makes the subquery an OPTIONAL CALL
      * @see {@link https://neo4j.com/docs/cypher-manual/current/subqueries/call-subquery/#optional-call | Cypher Documentation}
-     * @version Neo4j 5.24
+     * @since Neo4j 5.24
      */
     public optional(): this {
         this._optional = true;
@@ -115,7 +115,7 @@ export class Call extends Clause {
         const setCypher = this.compileSetCypher(env);
         const deleteCypher = compileCypherIfExists(this.deleteClause, env, { prefix: "\n" });
         const orderByCypher = compileCypherIfExists(this.orderByStatement, env, { prefix: "\n" });
-        const inTransactionCypher = this.generateInTransactionStr();
+        const inTransactionCypher = this.generateInTransactionsStr();
 
         const inCallBlock = `${importWithCypher}${subQueryStr}`;
         const variableScopeStr = this.generateVariableScopeStr(env);
@@ -147,7 +147,7 @@ export class Call extends Clause {
         return ` (${variablesString.join(", ")})`;
     }
 
-    private generateInTransactionStr(): string {
+    private generateInTransactionsStr(): string {
         if (!this.inTransactionsConfig) {
             return "";
         }

--- a/src/clauses/Finish.ts
+++ b/src/clauses/Finish.ts
@@ -22,6 +22,7 @@ import { Clause } from "./Clause";
 /**
  * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/finish/ | Cypher Documentation}
  * @group Clauses
+ * @since Neo4j 5.19
  */
 export class Finish extends Clause {
     /** @internal */

--- a/src/clauses/Match.ts
+++ b/src/clauses/Match.ts
@@ -128,6 +128,9 @@ export class Match extends Clause {
         return matchClause;
     }
 
+    /**
+     * @since Neo4j 5.21
+     */
     public shortest(k: number): this {
         this.shortestStatement = {
             type: "SHORTEST",
@@ -135,6 +138,10 @@ export class Match extends Clause {
         };
         return this;
     }
+
+    /**
+     * @since Neo4j 5.21
+     */
     public shortestGroups(k: number): this {
         this.shortestStatement = {
             type: "SHORTEST_GROUPS",
@@ -142,12 +149,20 @@ export class Match extends Clause {
         };
         return this;
     }
+
+    /**
+     * @since Neo4j 5.21
+     */
     public allShortest(): this {
         this.shortestStatement = {
             type: "ALL SHORTEST",
         };
         return this;
     }
+
+    /**
+     * @since Neo4j 5.21
+     */
     public any(): this {
         this.shortestStatement = {
             type: "ANY",

--- a/src/clauses/Union.ts
+++ b/src/clauses/Union.ts
@@ -41,6 +41,10 @@ export class Union extends Clause {
         return this;
     }
 
+    /**
+     * Adds the clause `DISTINCT` after `UNION`
+     * @since Neo4j.19
+     */
     public distinct(): this {
         this.unionType = "DISTINCT";
         return this;

--- a/src/clauses/mixins/sub-clauses/WithDelete.ts
+++ b/src/clauses/mixins/sub-clauses/WithDelete.ts
@@ -43,7 +43,7 @@ export abstract class WithDelete extends Mixin {
 
     /** Add a `NODETACH DELETE` subclause
      * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/delete/#delete-nodetach | Cypher Documentation}
-     * @version Neo4j 5.14
+     * @since Neo4j 5.14
      */
     public noDetachDelete(...deleteInput: DeleteInput): this {
         const deleteClause = this.createDeleteClause(deleteInput);

--- a/src/clauses/mixins/sub-clauses/WithOrder.ts
+++ b/src/clauses/mixins/sub-clauses/WithOrder.ts
@@ -55,7 +55,7 @@ export abstract class WithOrder extends Mixin {
 
     /** Add a `OFFSET` subclause. An alias to `SKIP`
      * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/skip/#offset-synonym | Cypher Documentation}
-     * @version Neo4j 5.24
+     * @since Neo4j 5.24
      */
     public offset(value: number | Expr): this {
         const orderByStatement = this.getOrCreateOrderBy();

--- a/src/expressions/functions/scalar.ts
+++ b/src/expressions/functions/scalar.ts
@@ -207,6 +207,7 @@ export function type(relationship: Expr): CypherFunction {
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-valueType | Cypher Documentation}
  * @group Functions
  * @category Scalar
+ * @since Neo4j 5.13
  */
 export function valueType(expr: Expr): CypherFunction {
     return new CypherFunction("valueType", [expr]);
@@ -216,6 +217,7 @@ export function valueType(expr: Expr): CypherFunction {
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-char_length | Cypher Documentation}
  * @group Functions
  * @category Scalar
+ * @since Neo4j 5.13
  */
 export function char_length(expr: Expr): CypherFunction {
     return new CypherFunction("char_length", [expr]);
@@ -225,7 +227,7 @@ export function char_length(expr: Expr): CypherFunction {
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-character_length | Cypher Documentation}
  * @group Functions
  * @category Scalar
- * @version Neo4j 5.13
+ * @since Neo4j 5.13
  */
 export function character_length(expr: Expr): CypherFunction {
     return new CypherFunction("character_length", [expr]);
@@ -235,7 +237,7 @@ export function character_length(expr: Expr): CypherFunction {
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-nullIf | Cypher Documentation}
  * @group Functions
  * @category Scalar
- * @version Neo4j 5.14
+ * @since Neo4j 5.14
  */
 export function nullIf(expr1: Expr, expr2: Expr): CypherFunction {
     return new CypherFunction("nullIf", [expr1, expr2]);

--- a/src/expressions/functions/string.ts
+++ b/src/expressions/functions/string.ts
@@ -28,6 +28,7 @@ import { CypherFunction } from "./CypherFunctions";
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/string/#functions-btrim | Cypher Documentation}
  * @group Functions
  * @category String
+ * @since Neo4j 5.20
  */
 export function btrim(original: string | Expr, trimCharacter?: string | Expr): CypherFunction {
     const normalizedOriginal = normalizeExpr(original);
@@ -48,6 +49,7 @@ export function left(original: Expr, length: Expr): CypherFunction {
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/string/#functions-lower | Cypher Documentation}
  * @group Functions
  * @category String
+ * @since Neo4j 5.21
  */
 export function lower(original: Expr): CypherFunction {
     return new CypherFunction("lower", [original]);
@@ -69,6 +71,7 @@ export function ltrim(original: Expr | string, trimCharacter?: string | Expr): C
  * @group Functions
  * @category String
  * @param normalForm - A string with the normal form to use or a Cypher expression
+ * @since Neo4j 5.17
  * @example `Cypher.normalize(param, "NFC")`
  */
 export function normalize(input: Expr, normalForm?: NormalizationType | Expr): CypherFunction {
@@ -206,6 +209,7 @@ export function trim(
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/string/#functions-upper | Cypher Documentation}
  * @group Functions
  * @category String
+ * @since Neo4j 5.21
  */
 export function upper(original: Expr): CypherFunction {
     return new CypherFunction("upper", [original]);

--- a/src/expressions/operations/comparison.ts
+++ b/src/expressions/operations/comparison.ts
@@ -229,6 +229,7 @@ export function matches(leftExpr: Expr, rightExpr: Expr): ComparisonOp {
  * @see {@link https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-comparison | Cypher Documentation}
  * @group Operators
  * @category Comparison
+ * @since Neo4j 5.17
  */
 export function isNormalized(leftExpr: Expr, normalizationType?: NormalizationType): ComparisonOp {
     return new NormalizationOperator("IS NORMALIZED", leftExpr, normalizationType);

--- a/src/expressions/operations/concat.ts
+++ b/src/expressions/operations/concat.ts
@@ -52,6 +52,7 @@ export class ConcatOp extends CypherASTNode {
  * @see {@link https://neo4j.com/docs/cypher-manual/current/syntax/operators/#syntax-concatenating-two-strings-doublebar | Cypher Documentation}
  * @group Operators
  * @category String
+ * @since Neo4j 5.19
  */
 export function concat(leftExpr: Expr, rightExpr: Expr): ConcatOp;
 export function concat(...exprs: Expr[]): ConcatOp;

--- a/src/namespaces/vector/similarity.ts
+++ b/src/namespaces/vector/similarity.ts
@@ -24,7 +24,8 @@ const VECTOR_SIMILARITY_NAMESPACE = "vector.similarity";
 
 /** Returns a FLOAT representing the similarity between the argument vectors based on their Euclidean distance.
  * @see [Neo4j Documentation](https://neo4j.com/docs/cypher-manual/current/functions/vector/#functions-similarity-euclidean)
- * @group Procedures
+ * @group Functions
+ * @since Neo4j 5.18
  */
 export function euclidean(a: Expr, b: Expr): CypherFunction {
     return new CypherFunction("euclidean", [a, b], VECTOR_SIMILARITY_NAMESPACE);
@@ -32,7 +33,8 @@ export function euclidean(a: Expr, b: Expr): CypherFunction {
 
 /** Returns a FLOAT representing the similarity between the argument vectors based on their cosine.
  * @see [Neo4j Documentation](https://neo4j.com/docs/cypher-manual/current/functions/vector/#functions-similarity-cosine)
- * @group Procedures
+ * @group Functions
+ * @since Neo4j 5.18
  */
 export function cosine(a: Expr, b: Expr): CypherFunction {
     return new CypherFunction("cosine", [a, b], VECTOR_SIMILARITY_NAMESPACE);

--- a/tsdoc.json
+++ b/tsdoc.json
@@ -1,10 +1,5 @@
 {
     "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
     "extends": ["typedoc/tsdoc.json"],
-    "tagDefinitions": [
-        {
-            "tagName": "@version",
-            "syntaxKind": "block"
-        }
-    ]
+    "tagDefinitions": []
 }


### PR DESCRIPTION
`@since` is the standard for features implemented in a particular version. Added these tags on features that were added in recent Neo4j versions.

This PR is not comprehensive, but should cover most features that were added since Neo4j 5.10

Only affects reference docs and IDEs tips