### PR TITLE
Add retry option to inTransaction

### DIFF
--- a/.changeset/lovely-parents-notice.md
+++ b/.changeset/lovely-parents-notice.md
@@ -1,0 +1,33 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Add option `retry` to `Call.inTransactions` configuration to add a `RETRY` statement to `CALL {} IN TRANSACTIONS`.
+This option can be a boolean set to true or a number to define the retry seconds:
+
+```js
+new Cypher.Call(subquery).inTransactions({
+    retry: true,
+});
+```
+
+```cypher
+CALL {
+    // ...
+} IN TRANSACTIONS ON ERROR RETRY
+```
+
+Using it in conjuntion with `onError` and with a defined seconds of retry:
+
+```js
+new Cypher.Call(subquery).inTransactions({
+    retry: 10,
+    onError: "break",
+});
+```
+
+```cypher
+CALL {
+    // ...
+} IN TRANSACTIONS ON ERROR RETRY FOR 10 SECONDS THEN BREAK
+```

--- a/docs/modules/ROOT/pages/subqueries/call.adoc
+++ b/docs/modules/ROOT/pages/subqueries/call.adoc
@@ -125,9 +125,10 @@ CALL {
 
 The method `inTransaction` accepts an object with the following options:
 
-* `ofRows`: A number to define the batch of rows. Translates to `IN TRANSACTIONS OF 10 ROWS`
-* `onError`: A behavior for error handling. This can be `continue`, `break` or `fail`. Translates to `ON ERROR CONTINUE`
-* `concurrentTransactions`: A number to execute concurrent transactions. Translates to `IN x CONCURRENT TRANSACTIONS`
+* `ofRows`: A number to define the batch of rows. Translates to `IN TRANSACTIONS OF 10 ROWS`.
+* `onError`: A behavior for error handling. This can be `continue`, `break` or `fail`. Translates to `ON ERROR CONTINUE`.
+* `concurrentTransactions`: A number to execute concurrent transactions. Translates to `IN x CONCURRENT TRANSACTIONS`.
+* `retry`: Either a boolean or a number. Translates to `ON ERROR RETRY [FOR x SECONDS]`. If `onError` is also defined, it will add `THEN [error]`.
 
 == Optional Call
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -20,8 +20,8 @@
     "dependencies": {
         "@antora/cli": "^3.1.10",
         "@antora/site-generator-default": "^3.1.10",
-        "@neo4j-antora/antora-add-notes": "^0.3.1",
-        "@neo4j-antora/antora-modify-sitemaps": "^0.7.0",
+        "@neo4j-antora/antora-add-notes": "^0.3.2",
+        "@neo4j-antora/antora-modify-sitemaps": "^0.7.1",
         "@neo4j-antora/antora-page-roles": "^0.3.2",
         "@neo4j-antora/antora-table-footnotes": "^0.3.3",
         "@neo4j-antora/mark-terms": "1.1.0",
@@ -29,7 +29,7 @@
         "@neo4j-documentation/remote-include": "^1.0.0"
     },
     "devDependencies": {
-        "express": "^5.0.0",
+        "express": "^5.1.0",
         "nodemon": "^3.1.9"
     },
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
         "globals": "^16.0.0",
         "jest": "^29.7.0",
         "jest-extended": "^4.0.2",
-        "neo4j-driver": "^5.26.0",
         "prettier": "^3.4.1",
         "ts-jest": "^29.2.5",
         "typedoc": "^0.28.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "neo4j-driver": "^5.26.0",
         "prettier": "^3.4.1",
         "ts-jest": "^29.2.5",
-        "typedoc": "^0.28.1",
+        "typedoc": "^0.28.2",
         "typescript": "^5.6.3"
     }
 }

--- a/src/utils/is-number.ts
+++ b/src/utils/is-number.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Check if something is a number */
+export function isNumber(n: unknown): n is number {
+    return typeof n === "number" && !Number.isNaN(n);
+}


### PR DESCRIPTION
Add option `retry` to `Call.inTransactions` configuration to add a `RETRY` statement to `CALL {} IN TRANSACTIONS`.
This option can be a boolean set to true or a number to define the retry seconds:

```js
new Cypher.Call(subquery).inTransactions({
    retry: true,
});
```

```cypher
CALL {
    // ...
} IN TRANSACTIONS ON ERROR RETRY
```

Using it in conjuntion with `onError` and with a defined seconds of retry:

```js
new Cypher.Call(subquery).inTransactions({
    retry: 10,
    onError: "break",
});
```

```cypher
CALL {
    // ...
} IN TRANSACTIONS ON ERROR RETRY FOR 10 SECONDS THEN BREAK
```