### PR TITLE
Fix types on methods .match and .optionalMatch

### DIFF
--- a/.changeset/sixty-impalas-stare.md
+++ b/.changeset/sixty-impalas-stare.md
@@ -1,0 +1,16 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Fix types to support paths on chained `.match` and `.optionalMatch`:
+
+```js
+const path = new Cypher.PathVariable();
+const query = new Cypher.Match(new Cypher.Node()).match(pattern.assignTo(path)).return(path);
+```
+
+```cypher
+MATCH (this0)
+MATCH p3 = (this0)-[this1:ACTED_IN]->(this2)
+RETURN p3
+```

--- a/src/clauses/Match.test.ts
+++ b/src/clauses/Match.test.ts
@@ -206,6 +206,60 @@ RETURN p3"
             `);
             expect(queryResult.params).toMatchInlineSnapshot(`{}`);
         });
+
+        test("using fluent match.match method", () => {
+            const path = new Cypher.PathVariable();
+
+            const query = new Cypher.Match(new Cypher.Pattern(a)).match(pattern.assignTo(path)).return(path);
+
+            const queryResult = query.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+MATCH p3 = (this0)-[this1:ACTED_IN]->(this2)
+RETURN p3"
+`);
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("using fluent with.match method", () => {
+            const path = new Cypher.PathVariable();
+
+            const query = new Cypher.With(a).match(pattern.assignTo(path)).return(path);
+
+            const queryResult = query.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"WITH this0
+MATCH p3 = (this0)-[this1:ACTED_IN]->(this2)
+RETURN p3"
+`);
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("in OptionalMatch", () => {
+            const path = new Cypher.PathVariable();
+
+            const query = new Cypher.OptionalMatch(pattern.assignTo(path)).return(path);
+
+            const queryResult = query.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"OPTIONAL MATCH p3 = (this0)-[this1:ACTED_IN]->(this2)
+RETURN p3"
+`);
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
+        test("with chained .optionalMatch", () => {
+            const path = new Cypher.PathVariable();
+
+            const query = new Cypher.Match(new Cypher.Pattern(a)).optionalMatch(pattern.assignTo(path)).return(path);
+
+            const queryResult = query.build();
+            expect(queryResult.cypher).toMatchInlineSnapshot(`
+"MATCH (this0)
+OPTIONAL MATCH p3 = (this0)-[this1:ACTED_IN]->(this2)
+RETURN p3"
+`);
+            expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+        });
     });
 
     describe("With where", () => {
@@ -923,7 +977,10 @@ RETURN this0"
             const m2 = new Cypher.Node();
 
             const quantifiedPath = new Cypher.QuantifiedPath(
-                new Cypher.Pattern(m, { labels: ["Movie"], properties: { title: new Cypher.Param("V for Vendetta") } }),
+                new Cypher.Pattern(m, {
+                    labels: ["Movie"],
+                    properties: { title: new Cypher.Param("V for Vendetta") },
+                }),
                 new Cypher.Pattern({ labels: ["Movie"] })
                     .related({ type: "ACTED_IN" })
                     .to({ labels: ["Person"] })

--- a/src/clauses/Match.ts
+++ b/src/clauses/Match.ts
@@ -58,6 +58,9 @@ type ShortestStatement = {
     k?: number;
 };
 
+/** Patterns supported by Match */
+export type MatchClausePattern = Pattern | QuantifiedPath | PathAssign<Pattern | QuantifiedPath>;
+
 /**
  * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/match/ | Cypher Documentation}
  * @group Clauses
@@ -78,11 +81,11 @@ type ShortestStatement = {
     WithForeach
 )
 export class Match extends Clause {
-    private readonly pattern: Pattern | QuantifiedPath | PathAssign<Pattern | QuantifiedPath>;
+    private readonly pattern: MatchClausePattern;
     private _optional = false;
     private shortestStatement: ShortestStatement | undefined;
 
-    constructor(pattern: Pattern | QuantifiedPath | PathAssign<Pattern | QuantifiedPath>) {
+    constructor(pattern: MatchClausePattern) {
         super();
         this.pattern = pattern;
     }
@@ -106,7 +109,7 @@ export class Match extends Clause {
     /** Add a {@link Match} clause
      * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/match/ | Cypher Documentation}
      */
-    public match(clauseOrPattern: Match | Pattern): Match {
+    public match(clauseOrPattern: Match | MatchClausePattern): Match {
         if (clauseOrPattern instanceof Match) {
             this.addNextClause(clauseOrPattern);
             return clauseOrPattern;
@@ -121,8 +124,12 @@ export class Match extends Clause {
     /** Add an {@link OptionalMatch} clause
      * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/optional-match/ | Cypher Documentation}
      */
-    public optionalMatch(pattern: Pattern): OptionalMatch {
-        const matchClause = new OptionalMatch(pattern);
+    public optionalMatch(clauseOrPattern: OptionalMatch | MatchClausePattern): OptionalMatch {
+        if (clauseOrPattern instanceof OptionalMatch) {
+            this.addNextClause(clauseOrPattern);
+            return clauseOrPattern;
+        }
+        const matchClause = new OptionalMatch(clauseOrPattern);
         this.addNextClause(matchClause);
 
         return matchClause;
@@ -208,7 +215,7 @@ export class Match extends Clause {
  * @group Clauses
  */
 export class OptionalMatch extends Match {
-    constructor(pattern: Pattern) {
+    constructor(pattern: MatchClausePattern) {
         super(pattern);
         this.optional();
     }

--- a/src/clauses/mixins/clauses/WithMatch.ts
+++ b/src/clauses/mixins/clauses/WithMatch.ts
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import type { Pattern } from "../../..";
 import { Match, OptionalMatch } from "../../..";
+import type { MatchClausePattern } from "../../Match";
 import { MixinClause } from "../Mixin";
 
 export abstract class WithMatch extends MixinClause {
@@ -26,7 +26,7 @@ export abstract class WithMatch extends MixinClause {
      * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/match/ | Cypher Documentation}
      */
 
-    public match(clauseOrPattern: Match | Pattern): Match {
+    public match(clauseOrPattern: Match | MatchClausePattern): Match {
         if (clauseOrPattern instanceof Match) {
             this.addNextClause(clauseOrPattern);
             return clauseOrPattern;
@@ -42,8 +42,12 @@ export abstract class WithMatch extends MixinClause {
      * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/optional-match/ | Cypher Documentation}
      */
 
-    public optionalMatch(pattern: Pattern): OptionalMatch {
-        const matchClause = new OptionalMatch(pattern);
+    public optionalMatch(clauseOrPattern: OptionalMatch | MatchClausePattern): OptionalMatch {
+        if (clauseOrPattern instanceof OptionalMatch) {
+            this.addNextClause(clauseOrPattern);
+            return clauseOrPattern;
+        }
+        const matchClause = new OptionalMatch(clauseOrPattern);
         this.addNextClause(matchClause);
 
         return matchClause;

--- a/typedoc.json
+++ b/typedoc.json
@@ -18,7 +18,7 @@
     "validation": {
         "invalidLink": true
     },
-    "intentionallyNotExported": ["CypherCompilable", "NamedReference"],
+    "intentionallyNotExported": ["CypherCompilable", "NamedReference", "MatchClausePattern"],
     "navigation": {
         "includeCategories": true,
         "includeGroups": true


### PR DESCRIPTION
Fix types to support paths on chained `.match` and `.optionalMatch`:

```js
const path = new Cypher.PathVariable();
const query = new Cypher.Match(new Cypher.Node()).match(pattern.assignTo(path)).return(path);
```

```cypher
MATCH (this0)
MATCH p3 = (this0)-[this1:ACTED_IN]->(this2)
RETURN p3
```