### PR TITLE
Compatibility doc

### DIFF
--- a/docs/modules/ROOT/content-nav.adoc
+++ b/docs/modules/ROOT/content-nav.adoc
@@ -41,6 +41,7 @@
 ** xref:how-to/filter-by-labels.adoc[]
 ** xref:how-to/update-labels.adoc[]
 ** xref:how-to/define-cypher-version.adoc[]
+* xref:compatibility.adoc[]
 * xref:migration-guide-2.adoc[]
 * link:https://github.com/neo4j/cypher-builder/tree/main/examples[Examples]
 * link:https://neo4j.github.io/cypher-builder/reference/[Reference]

--- a/docs/modules/ROOT/pages/compatibility.adoc
+++ b/docs/modules/ROOT/pages/compatibility.adoc
@@ -1,0 +1,13 @@
+[[compatibility]]
+:description: This page outlines the compatibility requirements for `@neo4j/cypher-builder` version 2 with Cypher and Node.js.
+= Compatibility
+
+This page outlines the compatibility requirements for `@neo4j/cypher-builder` version 2 with Cypher and Node.js.
+
+* Targets link:https://neo4j.com/docs/cypher-manual/5/introduction/[Cypher 5], with support for link:https://neo4j.com/docs/cypher-manual/4.4/introduction/[Cypher 4.4].
+* Compatible with Node.js version 16.0.0 and later.
+
+[NOTE]
+====
+`@neo4j/cypher-builder` version 1 is no longer supported. Version 2 is a full replacement and maintains the same compatibility with Cypher and Node.js.
+====


### PR DESCRIPTION
Adds a new page to outline the compatibility requirements between Cypher Builder, Cypher and Node.js.

This page will be more relevant once new versions of Cypher and Cypher Builder become available