### PR TITLE
540 optional call for procedures

### DIFF
--- a/.changeset/easy-eggs-count.md
+++ b/.changeset/easy-eggs-count.md
@@ -1,0 +1,13 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Add support for `OPTIONAL CALL` on procedures:
+
+```js
+Cypher.db.labels().yield("*").optional();
+```
+
+```cypher
+OPTIONAL CALL db.labels() YIELD *
+```

--- a/.changeset/easy-eggs-count.md
+++ b/.changeset/easy-eggs-count.md
@@ -1,11 +1,11 @@
 ---
-"@neo4j/cypher-builder": patch
+"@neo4j/cypher-builder": minor
 ---
 
 Add support for `OPTIONAL CALL` on procedures:
 
 ```js
-Cypher.db.labels().yield("*").optional();
+Cypher.db.labels().optional().yield("*");
 ```
 
 ```cypher

--- a/docs/modules/ROOT/pages/procedures.adoc
+++ b/docs/modules/ROOT/pages/procedures.adoc
@@ -78,6 +78,21 @@ const dbLabels = Cypher.db.labels().yield("label");
 CALL db.labels() YIELD label
 ----
 
+=== Optional
+
+Procedures can be called with `OPTIONAL CALL` by using the `.optional` method:
+
+[source, javascript]
+----
+Cypher.db.labels().yield("*").optional();
+----
+
+[source, cypher]
+----
+OPTIONAL CALL db.labels() YIELD *
+----
+
+
 == Reusing Custom Procedures
 
 Custom procedures can be wrapped within a function so these can be reused in the same fashion as built-in procedures:

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "jest-extended": "^5.0.0",
         "prettier": "^3.4.1",
         "ts-jest": "^29.2.5",
-        "typedoc": "^0.28.2",
+        "typedoc": "^0.28.5",
         "typescript": "^5.6.3"
     }
 }

--- a/src/namespaces/db/db.test.ts
+++ b/src/namespaces/db/db.test.ts
@@ -96,6 +96,14 @@ describe("db procedures", () => {
                 Cypher.db.labels().yield();
             }).toThrow("Empty projection in CALL ... YIELD");
         });
+
+        test("db.labels with yield *", () => {
+            const dbLabels = Cypher.db.labels().yield("*").optional();
+            const { cypher, params } = dbLabels.build();
+
+            expect(cypher).toMatchInlineSnapshot(`"OPTIONAL CALL db.labels() YIELD *"`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
     });
 
     test("db.ping", () => {

--- a/src/namespaces/db/db.test.ts
+++ b/src/namespaces/db/db.test.ts
@@ -98,7 +98,7 @@ describe("db procedures", () => {
         });
 
         test("db.labels with yield *", () => {
-            const dbLabels = Cypher.db.labels().yield("*").optional();
+            const dbLabels = Cypher.db.labels().optional().yield("*");
             const { cypher, params } = dbLabels.build();
 
             expect(cypher).toMatchInlineSnapshot(`"OPTIONAL CALL db.labels() YIELD *"`);

--- a/src/procedures/CypherProcedure.test.ts
+++ b/src/procedures/CypherProcedure.test.ts
@@ -120,18 +120,6 @@ describe("Procedures", () => {
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        test("Procedure with yield with optional", () => {
-            const targetNode = new Cypher.Node();
-            const customProcedure = new Cypher.Procedure<"test">("customProcedure", [targetNode])
-                .yield("test")
-                .optional();
-
-            const { cypher, params } = customProcedure.build();
-
-            expect(cypher).toMatchInlineSnapshot(`"OPTIONAL CALL customProcedure(this0) YIELD test"`);
-            expect(params).toMatchInlineSnapshot(`{}`);
-        });
-
         test("Optional procedure with yield with optional", () => {
             const targetNode = new Cypher.Node();
             const customProcedure = new Cypher.Procedure<"test">("customProcedure", [targetNode])

--- a/src/procedures/CypherProcedure.test.ts
+++ b/src/procedures/CypherProcedure.test.ts
@@ -100,6 +100,51 @@ describe("Procedures", () => {
         expect(params).toMatchInlineSnapshot(`{}`);
     });
 
+    describe("Optional", () => {
+        test("Procedure with optional", () => {
+            const targetNode = new Cypher.Node();
+            const customProcedure = new Cypher.Procedure("customProcedure", [targetNode]).optional();
+
+            const { cypher, params } = customProcedure.build();
+
+            expect(cypher).toMatchInlineSnapshot(`"OPTIONAL CALL customProcedure(this0)"`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
+        test("VoidProcedure with optional", () => {
+            const targetNode = new Cypher.Node();
+            const customProcedure = new Cypher.VoidProcedure("customProcedure", [targetNode]).optional();
+
+            const { cypher, params } = customProcedure.build();
+
+            expect(cypher).toMatchInlineSnapshot(`"OPTIONAL CALL customProcedure(this0)"`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("Procedure with yield with optional", () => {
+            const targetNode = new Cypher.Node();
+            const customProcedure = new Cypher.Procedure<"test">("customProcedure", [targetNode])
+                .yield("test")
+                .optional();
+
+            const { cypher, params } = customProcedure.build();
+
+            expect(cypher).toMatchInlineSnapshot(`"OPTIONAL CALL customProcedure(this0) YIELD test"`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
+
+        test("Optional procedure with yield with optional", () => {
+            const targetNode = new Cypher.Node();
+            const customProcedure = new Cypher.Procedure<"test">("customProcedure", [targetNode])
+                .optional()
+                .yield("test");
+
+            const { cypher, params } = customProcedure.build();
+
+            expect(cypher).toMatchInlineSnapshot(`"OPTIONAL CALL customProcedure(this0) YIELD test"`);
+            expect(params).toMatchInlineSnapshot(`{}`);
+        });
+    });
+
     describe("Procedure with Yield and nested clauses", () => {
         it("Procedure with Where", () => {
             const procedure = new Cypher.Procedure("custom-procedure").yield("test");

--- a/src/procedures/CypherProcedure.ts
+++ b/src/procedures/CypherProcedure.ts
@@ -96,10 +96,4 @@ export class CypherProcedure<T extends string = string> extends VoidCypherProced
 
         return `${callCypher}${yieldCypher}`;
     }
-
-    protected generateOptionalStr(): string {
-        const yieldOptional = Boolean(this.yieldStatement?._optional);
-        const hasOptional = this._optional || yieldOptional;
-        return hasOptional ? "OPTIONAL " : "";
-    }
 }

--- a/src/procedures/Yield.ts
+++ b/src/procedures/Yield.ts
@@ -72,12 +72,6 @@ export interface Yield
 )
 export class Yield<T extends string = string> extends Clause {
     private readonly projection: YieldProjection;
-    /**
-     * Used for `OPTIONAL CALL`
-     * @internal
-     *
-     */
-    public _optional: boolean = false;
 
     constructor(yieldColumns: Array<YieldProjectionColumn<T>>) {
         super();
@@ -88,11 +82,6 @@ export class Yield<T extends string = string> extends Clause {
 
     public yield(...columns: Array<YieldProjectionColumn<T>>): this {
         this.projection.addYieldColumns(columns);
-        return this;
-    }
-
-    public optional(): this {
-        this._optional = true;
         return this;
     }
 

--- a/src/procedures/Yield.ts
+++ b/src/procedures/Yield.ts
@@ -72,6 +72,12 @@ export interface Yield
 )
 export class Yield<T extends string = string> extends Clause {
     private readonly projection: YieldProjection;
+    /**
+     * Used for `OPTIONAL CALL`
+     * @internal
+     *
+     */
+    public _optional: boolean = false;
 
     constructor(yieldColumns: Array<YieldProjectionColumn<T>>) {
         super();
@@ -82,6 +88,11 @@ export class Yield<T extends string = string> extends Clause {
 
     public yield(...columns: Array<YieldProjectionColumn<T>>): this {
         this.projection.addYieldColumns(columns);
+        return this;
+    }
+
+    public optional(): this {
+        this._optional = true;
         return this;
     }
 


### PR DESCRIPTION
Add support for `OPTIONAL CALL` on procedures:

```js
Cypher.db.labels().yield("*").optional();
```

```cypher
OPTIONAL CALL db.labels() YIELD *
```