### PR TITLE
docs > clauses > match > Relationship example wrong

### DIFF
--- a/docs/modules/ROOT/pages/clauses/match.adoc
+++ b/docs/modules/ROOT/pages/clauses/match.adoc
@@ -46,16 +46,16 @@ Relationships can be used in a match clause by creating the relevant xref:/patte
 
 [source, javascript]
 ----
-const actedInPattern = new Cypher.Pattern(movieNode, { labels: ["Movie"] })
-    .related({ type: "ACTED_IN" direction: "left" })
-    .to(personNode, { labels: ["Person"] });
+const actedInPattern = new Cypher.Pattern(personNode, { labels: ["Person"] })
+    .related({ type: "ACTED_IN" })
+    .to(movieNode, { labels: ["Movie"] });
 
 const matchQuery = new Cypher.Match(actedInPattern)
 ----
 
 [source, cypher]
 ----
-MATCH (this0:Movie)<-[:ACTED_IN]-(this1:Person)
+MATCH (this0:Person)-[:ACTED_IN]->(this1:Movie)
 ----
 
 == Filtering with `WHERE`

--- a/docs/modules/ROOT/pages/clauses/match.adoc
+++ b/docs/modules/ROOT/pages/clauses/match.adoc
@@ -47,7 +47,7 @@ Relationships can be used in a match clause by creating the relevant xref:/patte
 [source, javascript]
 ----
 const actedInPattern = new Cypher.Pattern(movieNode, { labels: ["Movie"] })
-    .related({ type: "ACTED_IN" })
+    .related({ type: "ACTED_IN" direction: "left" })
     .to(personNode, { labels: ["Person"] });
 
 const matchQuery = new Cypher.Match(actedInPattern)
@@ -55,7 +55,7 @@ const matchQuery = new Cypher.Match(actedInPattern)
 
 [source, cypher]
 ----
-MATCH (this1:`Person`)-[this0:ACTED_IN]->(this2:`Movie`)
+MATCH (this0:Movie)<-[:ACTED_IN]-(this1:Person)
 ----
 
 == Filtering with `WHERE`


### PR DESCRIPTION
The relationship example creates cypher query, where a (movie)-[:ACTED_IN]->(person). The query shown as the result of this does not match.

I suggest adding the direction: "left", like in the "relationships-and-advanced-filtering" section, and adjusting the resulting query shown beneath.