### PR TITLE
Makes value in Cypher.Param writable

### DIFF
--- a/.changeset/petite-taxis-burn.md
+++ b/.changeset/petite-taxis-burn.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Makes value of `Cypher.Param` writable so it can be overwritten before the query is built

--- a/src/references/Param.ts
+++ b/src/references/Param.ts
@@ -24,7 +24,7 @@ import { Variable } from "./Variable";
  * @group Variables
  */
 export class Param<T = unknown> extends Variable {
-    public readonly value: T;
+    public value: T;
 
     constructor(value: T) {
         super();


### PR DESCRIPTION
Makes value of `Cypher.Param` writable so it can be overwritten before the query is built