### PR TITLE
Deprecations

### DIFF
--- a/.changeset/crazy-signs-kick.md
+++ b/.changeset/crazy-signs-kick.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecates `Call.importWith` in favor of scope variables in `Call` constructor

--- a/.changeset/lazy-buckets-peel.md
+++ b/.changeset/lazy-buckets-peel.md
@@ -1,0 +1,11 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecate apoc functions and procedures. These will no longer be supported in version 3 of Cypher Builder:
+
+- `apoc.date.convertFormat`
+- `apoc.util.validate`
+- `apoc.util.validatePredicate`
+- `apoc.cypher.runFirstColumnMany`
+- `apoc.cypher.runFirstColumnSingle`

--- a/docs/modules/ROOT/pages/functions.adoc
+++ b/docs/modules/ROOT/pages/functions.adoc
@@ -26,18 +26,18 @@ This differentiates functions from clauses and other elements of the Cypher Buil
 ====
 
 Exposed functions have the closest possible name to their Cypher counterpart, and reside in the same namespace.
-For example, this query:
+For example:
 
 [source, javascript]
 ----
-Cypher.apoc.cypher.runFirstColumnSingle()
+Cypher.db.nameFromElementId("1234")
 ----
 
-Is equivalent to the Cypher function:
+Generates the Cypher function:
 
 [source, cypher]
 ----
-apoc.cypher.runFirstColumnSingle()
+db.nameFromElementId("1234")
 ----
 
 == Custom functions

--- a/docs/modules/ROOT/pages/subqueries/call.adoc
+++ b/docs/modules/ROOT/pages/subqueries/call.adoc
@@ -69,6 +69,7 @@ CALL (*) {
 }
 ----
 
+[role=label--deprecated]
 == `.importWith`
 
 [WARNING]

--- a/docs/modules/ROOT/pages/subqueries/call.adoc
+++ b/docs/modules/ROOT/pages/subqueries/call.adoc
@@ -73,7 +73,12 @@ CALL (*) {
 
 [WARNING]
 ====
-Import with cannot be used if scope variables are defined and will throw an error
+This method is deprecated in favor of <<_variable_scope>> 
+====
+
+[WARNING]
+====
+Import with cannot be used if scope variables are defined and will throw an error.
 ====
 
 

--- a/src/clauses/Call.ts
+++ b/src/clauses/Call.ts
@@ -60,7 +60,9 @@ export type CallInTransactionOptions = {
     retry?: number | boolean;
 };
 
-/**
+/** Adds a `CALL` subquery
+ * @param subquery - A clause to be wrapped in a `CALL` clause
+ * @param variableScope - A list of variables to pass to the scope of the clause: `CALL (var0) {`
  * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/call-subquery/ | Cypher Documentation}
  * @group Subqueries
  */
@@ -81,7 +83,8 @@ export class Call extends Clause {
     }
 
     /** Adds a `WITH` statement inside `CALL {`, this `WITH` can is used to import variables outside of the subquery
-     *  @see {@link https://neo4j.com/docs/cypher-manual/current/subqueries/call-subquery/#call-importing-variables | Cypher Documentation}
+     * @see {@link https://neo4j.com/docs/cypher-manual/current/subqueries/call-subquery/#call-importing-variables | Cypher Documentation}
+     * @deprecated Use constructor parameter `variableScope` instead
      */
     public importWith(...params: Array<Variable | "*">): this {
         if (this._importWith) {

--- a/src/namespaces/apoc/cypher/run-first-column.ts
+++ b/src/namespaces/apoc/cypher/run-first-column.ts
@@ -26,6 +26,7 @@ import type { Expr } from "../../../types";
 
 /**
  * @group Functions
+ * @deprecated apoc methods will no longer be supported in Cypher Builder version 3
  * @see [Apoc Documentation](https://neo4j.com/docs/apoc/current/overview/apoc.cypher/apoc.cypher.runFirstColumnMany/)
  */
 export function runFirstColumnMany(
@@ -37,6 +38,7 @@ export function runFirstColumnMany(
 
 /**
  * @group Functions
+ * @deprecated apoc methods will no longer be supported in Cypher Builder version 3
  * @see [Apoc Documentation](https://neo4j.com/docs/apoc/current/overview/apoc.cypher/apoc.cypher.runFirstColumnSingle/)
  */
 export function runFirstColumnSingle(

--- a/src/namespaces/apoc/date.ts
+++ b/src/namespaces/apoc/date.ts
@@ -25,6 +25,7 @@ import type { Expr } from "../../types";
 /**
  * @group Functions
  * @see [Apoc Documentation](https://neo4j.com/docs/apoc/current/overview/apoc.date/apoc.date.convertFormat/)
+ * @deprecated apoc methods will no longer be supported in Cypher Builder version 3
  * @example
  * ```ts
  * Cypher.apoc.date.convertFormat(

--- a/src/namespaces/apoc/util.ts
+++ b/src/namespaces/apoc/util.ts
@@ -27,6 +27,7 @@ import { normalizeVariable } from "../../utils/normalize-variable";
 
 /**
  * @group Procedures
+ * @deprecated apoc methods will no longer be supported in Cypher Builder version 3
  * @see [Apoc Documentation](https://neo4j.com/docs/apoc/current/overview/apoc.util/apoc.util.validate/)
  */
 export function validate(
@@ -40,6 +41,7 @@ export function validate(
 
 /**
  * @group Functions
+ * @deprecated apoc methods will no longer be supported in Cypher Builder version 3
  * @see [Apoc Documentation](https://neo4j.com/docs/apoc/current/overview/apoc.util/apoc.util.validatePredicate/)
  */
 export function validatePredicate(predicate: Predicate, message: string): CypherFunction {


### PR DESCRIPTION
Adds some deprecations in preparation of Cypher-builder 3 and Cypher 25

Deprecates `Call.importWith` in favor of scope variables in `Call` constructor


Deprecate apoc functions and procedures. These will no longer be supported in version 3 of Cypher Builder:

- `apoc.date.convertFormat`
- `apoc.util.validate`
- `apoc.util.validatePredicate`
- `apoc.cypher.runFirstColumnMany`
- `apoc.cypher.runFirstColumnSingle`