### PR TITLE
enable isolatedModules in tsconfig

### DIFF
--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -151,7 +151,6 @@ export {
     radians,
     rand,
     round,
-    ROUND_PRECISION_MODE,
     sign,
     sin,
     sqrt,
@@ -168,7 +167,6 @@ export {
     duration,
     cypherLocalDatetime as localdatetime,
     cypherLocalTime as localtime,
-    TemporalUnit,
     cypherTime as time,
 } from "./expressions/functions/temporal";
 
@@ -183,7 +181,9 @@ export type { ProjectionColumn } from "./clauses/sub-clauses/Projection";
 export type { SetParam } from "./clauses/sub-clauses/Set";
 export type { CompositeClause } from "./clauses/utils/concat";
 export type { CypherAggregationFunction as AggregationFunction } from "./expressions/functions/aggregation";
+export type { ROUND_PRECISION_MODE } from "./expressions/functions/math";
 export type { PredicateFunction } from "./expressions/functions/predicate";
+export type { TemporalUnit } from "./expressions/functions/temporal";
 export type { HasLabel } from "./expressions/HasLabel";
 export type { LabelExpr, LabelOperator } from "./expressions/labels/label-expressions";
 export type { PathAssign } from "./pattern/PathAssign";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
         "baseUrl": ".",
         "outDir": "dist",
         "stripInternal": false, // TODO: Change this after validating output .d.ts
-        "noUncheckedIndexedAccess": true
+        "noUncheckedIndexedAccess": true,
+        "isolatedModules": true
     },
     "include": ["src/**/*", "tests/**/*", "global.d.ts"]
 }


### PR DESCRIPTION
After an update, jest has the following warning:

```
ts-jest[ts-compiler] (WARN) Using hybrid module kind (Node16/18/Next) is only supported in "isolatedModules: true". Please set "isolatedModules: true" in your tsconfig.json.
```

Setting `isolatedModules` seems to not affect the output according to [docs](https://www.typescriptlang.org/tsconfig/#isolatedModules) and only require minimal changes to the codebase, so this PR updates it

No changelog needed as this only affects the warnings and errors during build process 