### PR TITLE
Deprecate option labelOperator

### DIFF
--- a/.changeset/few-sides-switch.md
+++ b/.changeset/few-sides-switch.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecates the option `labelOperator`, this option only exists for compatibility with Cypher 4 and is no longer relevant for Cypher 5 or 25

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -38,10 +38,13 @@ export type BuildConfig = Partial<{
      * `MATCH (this:Movie:Film)`
      * `MATCH (this:Movie&Film)`
      *
+     * @deprecated This will be removed in the following major release and the value `"&"` will be used in the generated Cypher
+     *
      */
     labelOperator: ":" | "&";
     /** Will prefix generated queries with the Cypher version
-     * @example `CYPHER 5` */
+     * @example `CYPHER 5`
+     */
     cypherVersion: "5";
     /** Prefix variables with given string.
      *


### PR DESCRIPTION
Deprecates the option `labelOperator`, this option only exists for compatibility with Cypher 4 and is no longer relevant for Cypher 5 or 25