### PR TITLE
Remove functions deprecated in Cypher 5

### DIFF
--- a/.changeset/thin-radios-poke.md
+++ b/.changeset/thin-radios-poke.md
@@ -1,0 +1,8 @@
+---
+"@neo4j/cypher-builder": major
+---
+
+Remove functions deprecated in Cypher 5:
+
+- `distance` in favor of `point.distance`
+- `id` in favor of `elementId`

--- a/src/expressions/functions/scalar.test.ts
+++ b/src/expressions/functions/scalar.test.ts
@@ -31,7 +31,6 @@ describe("Scalar Functions", () => {
 
     // 1 parameter functions
     test.each([
-        "id",
         "elementId",
         "endNode",
         "size",

--- a/src/expressions/functions/scalar.ts
+++ b/src/expressions/functions/scalar.ts
@@ -59,16 +59,6 @@ export function head(expr: Expr): CypherFunction {
 }
 
 /**
- * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-id | Cypher Documentation}
- * @group Functions
- * @category Scalar
- * @deprecated Use {@link elementId} instead
- */
-export function id(variable: Expr): CypherFunction {
-    return new CypherFunction("id", [variable]);
-}
-
-/**
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/scalar/#functions-last | Cypher Documentation}
  * @group Functions
  * @category Scalar

--- a/src/expressions/functions/spatial.test.ts
+++ b/src/expressions/functions/spatial.test.ts
@@ -17,23 +17,10 @@
  * limitations under the License.
  */
 
-import { TestClause } from "../../utils/TestClause";
 import Cypher from "../..";
+import { TestClause } from "../../utils/TestClause";
 
 describe("Spatial Functions", () => {
-    describe("4.x deprecated functions", () => {
-        test.each(["distance"] as const)("%s", (value) => {
-            const leftExpr = new Cypher.Variable();
-            const rightExpr = new Cypher.Variable();
-            const spatialFn = Cypher[value](leftExpr, rightExpr);
-
-            const queryResult = new TestClause(spatialFn).build();
-
-            expect(queryResult.cypher).toBe(`${value}(var0, var1)`);
-            expect(queryResult.params).toEqual({});
-        });
-    });
-
     test("point function", () => {
         const pointFn = Cypher.point(new Cypher.Variable());
 

--- a/src/expressions/functions/spatial.ts
+++ b/src/expressions/functions/spatial.ts
@@ -30,16 +30,6 @@ export function point(variable: Expr): CypherFunction {
 }
 
 /**
- * @see {@link https://neo4j.com/docs/cypher-manual/4.3/functions/spatial/#functions-distance | Cypher Documentation}
- * @group Functions
- * @category Spatial
- * @deprecated No longer supported in Neo4j 5. Use {@link point.distance} instead.
- */
-export function distance(lexpr: Expr, rexpr: Expr): CypherFunction {
-    return new CypherFunction("distance", [lexpr, rexpr]);
-}
-
-/**
  * @see {@link https://neo4j.com/docs/cypher-manual/current/functions/spatial/#functions-distance | Cypher Documentation}
  * @group Functions
  * @category Spatial


### PR DESCRIPTION
Remove functions deprecated in Cypher 5:

- `distance` in favor of `point.distance`
- `id` in favor of `elementId`