### PR TITLE
Remove support for patterns in size

### DIFF
--- a/.changeset/common-cycles-obey.md
+++ b/.changeset/common-cycles-obey.md
@@ -1,0 +1,11 @@
+---
+"@neo4j/cypher-builder": major
+---
+
+Remove support for patterns in size.
+
+_No longer supported_
+
+```js
+Cypher.size(new Cypher.Pattern(node));
+```

--- a/src/expressions/functions/scalar.test.ts
+++ b/src/expressions/functions/scalar.test.ts
@@ -103,12 +103,4 @@ describe("Scalar Functions", () => {
 
         expect(queryResult.cypher).toMatchInlineSnapshot(`"size(\\"Hello\\")"`);
     });
-
-    test("size() applied to a pattern", () => {
-        const pattern = new Cypher.Pattern(new Cypher.Node()).related().to();
-        const cypherFunction = Cypher.size(pattern);
-        const queryResult = new TestClause(cypherFunction).build();
-
-        expect(queryResult.cypher).toMatchInlineSnapshot(`"size((this0)-[]->())"`);
-    });
 });

--- a/src/expressions/functions/scalar.ts
+++ b/src/expressions/functions/scalar.ts
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import { Raw } from "../../clauses/Raw";
-import type { Pattern } from "../../pattern/Pattern";
 import type { Expr } from "../../types";
 import { CypherFunction } from "./CypherFunctions";
 
@@ -109,17 +107,8 @@ export function randomUUID(): CypherFunction {
  * @group Functions
  * @category Scalar
  */
-export function size(expr: Expr): CypherFunction;
-/** @deprecated size() with pattern is deprecated in Neo4j 5 */
-export function size(expr: Pattern): CypherFunction;
-export function size(expr: Expr | Pattern): CypherFunction {
-    // Support for patterns in size() in Neo4j 4
-    // Using Raw to avoid adding Patterns to CypherFunction
-    const sizeParam = new Raw((env) => {
-        return env.compile(expr);
-    });
-
-    return new CypherFunction("size", [sizeParam]);
+export function size(expr: Expr): CypherFunction {
+    return new CypherFunction("size", [expr]);
 }
 
 /**


### PR DESCRIPTION
Remove support for patterns in size.

_No longer supported_

```js
Cypher.size(new Cypher.Pattern(node));
```