### PR TITLE
Support for Cypher 25 prefix

### DIFF
--- a/.changeset/blue-ends-relate.md
+++ b/.changeset/blue-ends-relate.md
@@ -1,0 +1,11 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Add support for `Cypher 25` version prefix:
+
+```js
+const { cypher } = matchQuery.build({
+    cypherVersion: "25",
+});
+```

--- a/src/clauses/Clause.ts
+++ b/src/clauses/Clause.ts
@@ -45,7 +45,7 @@ export type BuildConfig = Partial<{
     /** Will prefix generated queries with the Cypher version
      * @example `CYPHER 5`
      */
-    cypherVersion: "5";
+    cypherVersion: "5" | "25";
     /** Prefix variables with given string.
      *
      * This is useful to avoid name collisions if separate Cypher queries are generated and merged after generating the strings.

--- a/tests/build-config/cypher-version.test.ts
+++ b/tests/build-config/cypher-version.test.ts
@@ -20,7 +20,7 @@
 import Cypher from "../../src";
 
 describe("Cypher version", () => {
-    test("Add cypher version on .build", () => {
+    test("Add cypher version 5 on .build", () => {
         const movieNode = new Cypher.Node();
         const pattern = new Cypher.Pattern(movieNode, { labels: ["Movie"] });
 
@@ -36,6 +36,28 @@ describe("Cypher version", () => {
 
         expect(cypher).toMatchInlineSnapshot(`
 "CYPHER 5
+MATCH (this0:Movie)
+WHERE this0.title = $param0
+RETURN this0.title"
+`);
+    });
+
+    test("Add cypher version 25 on .build", () => {
+        const movieNode = new Cypher.Node();
+        const pattern = new Cypher.Pattern(movieNode, { labels: ["Movie"] });
+
+        const matchQuery = new Cypher.Match(pattern)
+            .where(movieNode, {
+                title: new Cypher.Param("The Matrix"),
+            })
+            .return(movieNode.property("title"));
+
+        const { cypher } = matchQuery.build({
+            cypherVersion: "25",
+        });
+
+        expect(cypher).toMatchInlineSnapshot(`
+"CYPHER 25
 MATCH (this0:Movie)
 WHERE this0.title = $param0
 RETURN this0.title"


### PR DESCRIPTION
Add support for `Cypher 25` version prefix:

```js
const { cypher } = matchQuery.build({
    cypherVersion: "25",
});
```