### PR TITLE
Remove globals dev dependency

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,6 @@ import js from "@eslint/js";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
 import tsdoc from "eslint-plugin-tsdoc";
-import globals from "globals";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -32,10 +31,6 @@ export default [
         },
 
         languageOptions: {
-            globals: {
-                ...globals.node,
-            },
-
             parser: tsParser,
             ecmaVersion: 5,
             sourceType: "commonjs",

--- a/package.json
+++ b/package.json
@@ -53,12 +53,11 @@
         "eslint": "^9.15.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-plugin-tsdoc": "^0.4.0",
-        "globals": "^16.0.0",
         "jest": "^29.7.0",
         "jest-extended": "^6.0.0",
         "prettier": "^3.4.1",
         "ts-jest": "^29.2.5",
-        "typedoc": "^0.28.10",
+        "typedoc": "^0.28.13",
         "typescript": "^5.6.3"
     }
 }


### PR DESCRIPTION
We don't seem to be used the globals dependency (lint seems to be working fine without it)