### PR TITLE
List comprehension in

### DIFF
--- a/.changeset/bright-meals-arrive.md
+++ b/.changeset/bright-meals-arrive.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": major
+---
+
+ListComprehension `.in` method no longer throws if called twice. It will instead override the expression

--- a/.changeset/clean-items-greet.md
+++ b/.changeset/clean-items-greet.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": major
+---
+
+Remove second parameter of `ListComprehension` in favor of `.in`

--- a/src/expressions/list/ListComprehension.test.ts
+++ b/src/expressions/list/ListComprehension.test.ts
@@ -91,13 +91,24 @@ describe("List comprehension", () => {
         `);
     });
 
-    test("Fails to set a expression twice", () => {
+    test("Overrides if a expression is set twice", () => {
         const variable = new Cypher.Variable();
         const exprVariable = new Cypher.Param([1, 2, 5]);
+        const exprVariable2 = new Cypher.Param([1, 3]);
 
-        expect(() => {
-            new Cypher.ListComprehension(variable).in(exprVariable).in(exprVariable);
-        }).toThrow("Cannot set 2 lists in list comprehension IN");
+        const listComprehension = new Cypher.ListComprehension(variable).in(exprVariable).in(exprVariable2);
+
+        const queryResult = new TestClause(listComprehension).build();
+
+        expect(queryResult.cypher).toMatchInlineSnapshot(`"[var0 IN $param0]"`);
+        expect(queryResult.params).toMatchInlineSnapshot(`
+            {
+              "param0": [
+                1,
+                3,
+              ],
+            }
+        `);
     });
 
     test("Fails to build if no expression is set", () => {

--- a/src/expressions/list/ListComprehension.test.ts
+++ b/src/expressions/list/ListComprehension.test.ts
@@ -91,7 +91,7 @@ describe("List comprehension", () => {
         `);
     });
 
-    it("Fails to set a expression twice", () => {
+    test("Fails to set a expression twice", () => {
         const variable = new Cypher.Variable();
         const exprVariable = new Cypher.Param([1, 2, 5]);
 
@@ -100,7 +100,7 @@ describe("List comprehension", () => {
         }).toThrow("Cannot set 2 lists in list comprehension IN");
     });
 
-    it("Fails to build if no expression is set", () => {
+    test("Fails to build if no expression is set", () => {
         const variable = new Cypher.Variable();
 
         const listComprehension = new Cypher.ListComprehension(variable);

--- a/src/expressions/list/ListComprehension.test.ts
+++ b/src/expressions/list/ListComprehension.test.ts
@@ -25,7 +25,7 @@ describe("List comprehension", () => {
         const variable = new Cypher.Variable();
         const exprVariable = new Cypher.Param([1, 2, 5]);
 
-        const listComprehension = new Cypher.ListComprehension(variable, exprVariable);
+        const listComprehension = new Cypher.ListComprehension(variable).in(exprVariable);
 
         const queryResult = new TestClause(listComprehension).build();
 
@@ -47,7 +47,7 @@ describe("List comprehension", () => {
         const exprVariable = new Cypher.Param([1, 2, 5]);
         const andExpr = Cypher.eq(variable, new Cypher.Param(5));
 
-        const listComprehension = new Cypher.ListComprehension(variable, exprVariable).where(andExpr);
+        const listComprehension = new Cypher.ListComprehension(variable).in(exprVariable).where(andExpr);
 
         const queryResult = new TestClause(listComprehension).build();
 
@@ -96,7 +96,7 @@ describe("List comprehension", () => {
         const exprVariable = new Cypher.Param([1, 2, 5]);
 
         expect(() => {
-            new Cypher.ListComprehension(variable, exprVariable).in(exprVariable);
+            new Cypher.ListComprehension(variable).in(exprVariable).in(exprVariable);
         }).toThrow("Cannot set 2 lists in list comprehension IN");
     });
 

--- a/src/expressions/list/ListComprehension.ts
+++ b/src/expressions/list/ListComprehension.ts
@@ -38,10 +38,9 @@ export class ListComprehension extends CypherASTNode {
     private listExpr: Expr | undefined;
     private mapExpr: Expr | undefined; //  Expression for list mapping
 
-    constructor(variable: Variable, listExpr?: Expr) {
+    constructor(variable: Variable) {
         super();
         this.variable = variable;
-        this.listExpr = listExpr;
     }
 
     public in(listExpr: Expr): this {

--- a/src/expressions/list/ListComprehension.ts
+++ b/src/expressions/list/ListComprehension.ts
@@ -43,8 +43,8 @@ export class ListComprehension extends CypherASTNode {
         this.variable = variable;
     }
 
+    /** Sets the list expression to be used for the comprehension. If called twice, the expression will be overriden */
     public in(listExpr: Expr): this {
-        if (this.listExpr) throw new Error("Cannot set 2 lists in list comprehension IN");
         this.listExpr = listExpr;
         return this;
     }

--- a/src/pattern/Pattern.test.ts
+++ b/src/pattern/Pattern.test.ts
@@ -283,9 +283,7 @@ describe("Patterns", () => {
             const a = new Cypher.Node();
             const rel = new Cypher.Variable();
 
-            const query = new TestClause(
-                new Cypher.Pattern(a as Cypher.Node | undefined).related(rel).to(a as Cypher.Node | undefined)
-            );
+            const query = new TestClause(new Cypher.Pattern(a).related(rel).to(a));
             const queryResult = query.build();
             expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0)-[var1]->(this0)"`);
 
@@ -429,7 +427,7 @@ describe("Patterns", () => {
     });
 
     describe("Where predicate", () => {
-        it("Node pattern with where predicate", () => {
+        test("Node pattern with where predicate", () => {
             const node = new Cypher.Node();
 
             const pattern = new Cypher.Pattern(node, { labels: ["TestLabel"] }).where(
@@ -439,7 +437,7 @@ describe("Patterns", () => {
             expect(queryResult.cypher).toMatchInlineSnapshot(`"(this0:TestLabel WHERE this0.name = \\"Keanu\\")"`);
         });
 
-        it("Node pattern with where predicate and properties", () => {
+        test("Node pattern with where predicate and properties", () => {
             const node = new Cypher.Node();
 
             const pattern = new Cypher.Pattern(node, {
@@ -457,7 +455,7 @@ describe("Patterns", () => {
             );
         });
 
-        it("Node pattern with where predicate in target node", () => {
+        test("Node pattern with where predicate in target node", () => {
             const node = new Cypher.Node();
 
             const pattern = new Cypher.Pattern(node, { labels: ["TestLabel"] })
@@ -470,7 +468,7 @@ describe("Patterns", () => {
             );
         });
 
-        it("Relationship pattern with where predicate", () => {
+        test("Relationship pattern with where predicate", () => {
             const node = new Cypher.Node();
             const relationship = new Cypher.Relationship();
 
@@ -484,7 +482,7 @@ describe("Patterns", () => {
             );
         });
 
-        it("Relationship pattern with where predicate and properties", () => {
+        test("Relationship pattern with where predicate and properties", () => {
             const node = new Cypher.Node();
             const relationship = new Cypher.Relationship();
 

--- a/src/procedures/CypherProcedure.test.ts
+++ b/src/procedures/CypherProcedure.test.ts
@@ -134,7 +134,7 @@ describe("Procedures", () => {
     });
 
     describe("Procedure with Yield and nested clauses", () => {
-        it("Procedure with Where", () => {
+        test("Procedure with Where", () => {
             const procedure = new Cypher.Procedure("custom-procedure").yield("test");
 
             procedure.where(Cypher.true).and(Cypher.false).return("*");
@@ -148,7 +148,7 @@ RETURN *"
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        it("Procedure with Delete", () => {
+        test("Procedure with Delete", () => {
             const procedure = new Cypher.Procedure("custom-procedure").yield("test");
 
             procedure.delete(new Cypher.Node());
@@ -161,7 +161,7 @@ DELETE this0"
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        it("Procedure with Detach Delete", () => {
+        test("Procedure with Detach Delete", () => {
             const procedure = new Cypher.Procedure("custom-procedure").yield("test");
 
             procedure.detachDelete(new Cypher.Node());
@@ -174,7 +174,7 @@ DETACH DELETE this0"
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        it("Procedure with Remove", () => {
+        test("Procedure with Remove", () => {
             const procedure = new Cypher.Procedure("custom-procedure").yield("test");
 
             procedure.remove(new Cypher.Node().property("test"));
@@ -187,7 +187,7 @@ REMOVE this0.test"
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        it("Procedure with Set", () => {
+        test("Procedure with Set", () => {
             const procedure = new Cypher.Procedure("custom-procedure").yield("test");
 
             procedure.set([new Cypher.Variable().property("test"), new Cypher.Literal("hello")]);
@@ -201,7 +201,7 @@ SET
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        it("Procedure with Unwind", () => {
+        test("Procedure with Unwind", () => {
             const yieldVar = new Cypher.Variable();
             const procedure = new Cypher.Procedure("custom-procedure").yield(["test", yieldVar]);
 
@@ -215,7 +215,7 @@ UNWIND var0 AS var1"
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        it("Procedure with Merge", () => {
+        test("Procedure with Merge", () => {
             const procedure = new Cypher.Procedure("custom-procedure").yield("test");
 
             procedure.merge(new Cypher.Pattern(new Cypher.Node()));
@@ -228,7 +228,7 @@ MERGE (this0)"
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        it("Procedure with Create", () => {
+        test("Procedure with Create", () => {
             const procedure = new Cypher.Procedure("custom-procedure").yield("test");
 
             procedure.create(new Cypher.Pattern(new Cypher.Node()));
@@ -241,7 +241,7 @@ CREATE (this0)"
             expect(params).toMatchInlineSnapshot(`{}`);
         });
 
-        it("Procedure with Order by", () => {
+        test("Procedure with Order by", () => {
             const testVar = new Cypher.NamedVariable("test");
             const procedure = new Cypher.Procedure("custom-procedure").yield("test").orderBy(testVar).skip(1).limit(10);
 

--- a/src/utils/utils.test.ts
+++ b/src/utils/utils.test.ts
@@ -83,7 +83,7 @@ describe("CypherBuilder Utils", () => {
         });
     });
 
-    it("toCypherParams", () => {
+    test("toCypherParams", () => {
         const cypherParams = Cypher.utils.toCypherParams({
             param1: "my param",
             param2: 5,


### PR DESCRIPTION
Breaking changes on `ListComprehension`:

* ListComprehension `.in` method no longer throws if called twice. It will instead override the expression
* Remove second parameter of `ListComprehension` in favor of `.in`


Fix #441 