### PR TITLE
Deprecate second parameter of ListComprehension

### DIFF
--- a/.changeset/giant-items-exist.md
+++ b/.changeset/giant-items-exist.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Deprecates second parameter of `new ListComprehension` in favor of `.in`

--- a/src/expressions/list/ListComprehension.ts
+++ b/src/expressions/list/ListComprehension.ts
@@ -38,6 +38,9 @@ export class ListComprehension extends CypherASTNode {
     private listExpr: Expr | undefined;
     private mapExpr: Expr | undefined; //  Expression for list mapping
 
+    constructor(variable: Variable);
+    /** @deprecated Use `new ListComprehension(var1).in(expr)` instead */
+    constructor(variable: Variable, listExpr: Expr);
     constructor(variable: Variable, listExpr?: Expr) {
         super();
         this.variable = variable;


### PR DESCRIPTION
This deprecation relates to the breaking change in #585 