### PR TITLE
Add support for index operator on arbitrary expressions

### DIFF
--- a/.changeset/plain-monkeys-juggle.md
+++ b/.changeset/plain-monkeys-juggle.md
@@ -1,0 +1,13 @@
+---
+"@neo4j/cypher-builder": minor
+---
+
+Support for index operator on arbitrary expressions using `listIndex`
+
+```js
+Cypher.listIndex(Cypher.collect(new Cypher.Variable()), 2);
+```
+
+```cypher
+collect(var0)[2]
+```

--- a/docs/modules/ROOT/pages/variables-and-params/lists.adoc
+++ b/docs/modules/ROOT/pages/variables-and-params/lists.adoc
@@ -37,7 +37,7 @@ You can use instead `new Cypher.Literal(["element 1", "element 2"])` to avoid ve
 
 
 == Index
-With the `.index` method of a variable, you can create index access for lists:
+Use the `.index` method of a variable or `List` to create an index access:
 
 
 [source, javascript]
@@ -50,6 +50,19 @@ myVariable.index(2)
 var0[2]
 ----
 
+=== Index operator on arbitrary expressions
+
+To create an index on an arbitrary expression, like a function, use `Cypher.listIndex`:
+
+[source, javascript]
+----
+Cypher.listIndex(Cypher.collect(new Cypher.Variable()), 2);
+----
+
+[source, cypher]
+----
+collect(var0)[2]
+----
 
 == List comprehension
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,10 +18,10 @@
     "author": "Neo4j",
     "license": "ISC",
     "dependencies": {
-        "@antora/cli": "^3.1.10",
-        "@antora/site-generator-default": "^3.1.10",
+        "@antora/cli": "^3.1.14",
+        "@antora/site-generator-default": "^3.1.14",
         "@neo4j-antora/antora-add-notes": "^0.3.2",
-        "@neo4j-antora/antora-modify-sitemaps": "^0.7.1",
+        "@neo4j-antora/antora-modify-sitemaps": "^0.7.2",
         "@neo4j-antora/antora-page-roles": "^0.3.2",
         "@neo4j-antora/antora-table-footnotes": "^0.3.3",
         "@neo4j-antora/mark-terms": "1.1.0",
@@ -30,7 +30,7 @@
     },
     "devDependencies": {
         "express": "^5.1.0",
-        "nodemon": "^3.1.9"
+        "nodemon": "^3.1.10"
     },
     "overrides": {
         "@antora/site-generator-default": {

--- a/src/Cypher.ts
+++ b/src/Cypher.ts
@@ -82,7 +82,7 @@ export * as vector from "./namespaces/vector/vector";
 // --Lists
 export { ListComprehension } from "./expressions/list/ListComprehension";
 export { ListExpr as List } from "./expressions/list/ListExpr";
-export type { ListIndex } from "./expressions/list/ListIndex";
+export { listIndex, type ListIndex } from "./expressions/list/ListIndex";
 export { PatternComprehension } from "./expressions/list/PatternComprehension";
 
 // --Map

--- a/src/expressions/list/ListExpr.ts
+++ b/src/expressions/list/ListExpr.ts
@@ -19,7 +19,8 @@
 
 import type { CypherEnvironment } from "../../Environment";
 import type { CypherCompilable, Expr } from "../../types";
-import { ListIndex } from "./ListIndex";
+import type { ListIndex } from "./ListIndex";
+import { listIndex } from "./ListIndex";
 
 /** Represents a List
  * @see {@link https://neo4j.com/docs/cypher-manual/current/syntax/lists/ | Cypher Documentation}
@@ -56,6 +57,6 @@ export class ListExpr implements CypherCompilable {
 
     /** Access individual elements in the list */
     public index(index: number): ListIndex {
-        return new ListIndex(this, index);
+        return listIndex(this, index);
     }
 }

--- a/src/expressions/list/ListIndex.test.ts
+++ b/src/expressions/list/ListIndex.test.ts
@@ -19,15 +19,23 @@
 
 import Cypher from "../..";
 import { TestClause } from "../../utils/TestClause";
-import { ListIndex } from "./ListIndex";
 
 describe("ListIndex", () => {
-    test("get 0", () => {
+    test("get 0 from list", () => {
         const list = new Cypher.List([new Cypher.Literal("1"), new Cypher.Literal("2"), new Cypher.Literal("3")]);
-        const listIndex = new ListIndex(list, 0);
+        const listIndex = Cypher.listIndex(list, 0);
         const queryResult = new TestClause(listIndex).build();
 
         expect(queryResult.cypher).toMatchInlineSnapshot(`"[\\"1\\", \\"2\\", \\"3\\"][0]"`);
+        expect(queryResult.params).toMatchInlineSnapshot(`{}`);
+    });
+
+    test("get index from arbitrary expression", () => {
+        const collect = Cypher.collect(new Cypher.Variable());
+        const listIndex = Cypher.listIndex(collect, 2);
+        const queryResult = new TestClause(listIndex).build();
+
+        expect(queryResult.cypher).toMatchInlineSnapshot(`"collect(var0)[2]"`);
         expect(queryResult.params).toMatchInlineSnapshot(`{}`);
     });
 });

--- a/src/expressions/list/ListIndex.ts
+++ b/src/expressions/list/ListIndex.ts
@@ -18,22 +18,19 @@
  */
 
 import type { CypherEnvironment } from "../../Environment";
-import type { PropertyRef } from "../../references/PropertyRef";
-import type { Variable } from "../../references/Variable";
-import type { CypherCompilable } from "../../types";
-import type { ListExpr } from "./ListExpr";
+import type { CypherCompilable, Expr } from "../../types";
 
 /**
  * @group Lists
  */
 export class ListIndex implements CypherCompilable {
-    private readonly value: Variable | ListExpr | PropertyRef;
+    private readonly value: Expr;
     private readonly index: number;
 
     /**
      * @internal
      */
-    constructor(variable: Variable | ListExpr | PropertyRef, index: number) {
+    constructor(variable: Expr, index: number) {
         this.value = variable;
         this.index = index;
     }
@@ -42,4 +39,14 @@ export class ListIndex implements CypherCompilable {
     public getCypher(env: CypherEnvironment): string {
         return `${this.value.getCypher(env)}[${this.index}]`;
     }
+}
+
+/** Adds a index access operator (`[ ]`) to an expression
+ * @example
+ * ```cypher
+ * collect(var)[0]
+ * ```
+ */
+export function listIndex(expr: Expr, index: number): ListIndex {
+    return new ListIndex(expr, index);
 }

--- a/src/references/Variable.ts
+++ b/src/references/Variable.ts
@@ -18,7 +18,8 @@
  */
 
 import type { CypherEnvironment } from "../Environment";
-import { ListIndex } from "../expressions/list/ListIndex";
+import type { ListIndex } from "../expressions/list/ListIndex";
+import { listIndex } from "../expressions/list/ListIndex";
 import type { Expr } from "../types";
 import { escapeVariable } from "../utils/escape";
 import { PropertyRef } from "./PropertyRef";
@@ -43,7 +44,7 @@ export class Variable {
 
     /* Access individual elements via the ListIndex class, using the square bracket notation */
     public index(index: number): ListIndex {
-        return new ListIndex(this, index);
+        return listIndex(this, index);
     }
 
     /** @internal */


### PR DESCRIPTION
Add support for index operator on arbitrary expressions using `listIndex`

```js
Cypher.listIndex(Cypher.collect(new Cypher.Variable()), 2);
```

```cypher
collect(var0)[2]
```

This feature may change in version 3

Close #229