### PR TITLE
Remove methods and classes marked as internal from production build

### DIFF
--- a/.changeset/cuddly-sails-report.md
+++ b/.changeset/cuddly-sails-report.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Disable emit for methods and classes marked as internal

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
         "noImplicitAny": true,
         "rootDir": ".",
         "outDir": "dist",
-        "stripInternal": false, // TODO: Change this after validating output .d.ts
+        "stripInternal": false,
         "noUncheckedIndexedAccess": true,
         "isolatedModules": true
     },

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -4,7 +4,8 @@
         "rootDir": "src",
         "outDir": "dist",
         "declarationMap": false,
-        "sourceMap": false
+        "sourceMap": false,
+        "stripInternal": true
     },
     "exclude": ["src/**/*.test.ts"],
     "include": ["src/**/*"]


### PR DESCRIPTION
This avoids access to classes and methods marked as `@internal` in the production code

> Warning: This could technically break some users' code, as it is removing a surface that wasn't intended to be used