### PR TITLE
refactor mixins to avoid duplicate methods between a clause and mixin

### DIFF
--- a/src/clauses/Create.ts
+++ b/src/clauses/Create.ts
@@ -8,6 +8,7 @@ import { PathAssign } from "../pattern/PathAssign";
 import { Pattern } from "../pattern/Pattern";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
 import { Clause } from "./Clause";
+import { WithCreate } from "./mixins/clauses/WithCreate";
 import { WithFilter } from "./mixins/clauses/WithFilter";
 import { WithFinish } from "./mixins/clauses/WithFinish";
 import { WithLet } from "./mixins/clauses/WithLet";
@@ -20,13 +21,34 @@ import { WithSetRemove } from "./mixins/sub-clauses/WithSetRemove";
 import { mixin } from "./utils/mixin";
 
 export interface Create
-    extends WithReturn, WithSetRemove, WithWith, WithDelete, WithMerge, WithFinish, WithOrder, WithLet, WithFilter {}
+    extends
+        WithReturn,
+        WithSetRemove,
+        WithWith,
+        WithDelete,
+        WithMerge,
+        WithFinish,
+        WithOrder,
+        WithLet,
+        WithFilter,
+        WithCreate {}
 
 /**
  * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/create/ | Cypher Documentation}
  * @group Clauses
  */
-@mixin(WithReturn, WithSetRemove, WithWith, WithDelete, WithMerge, WithFinish, WithOrder, WithLet, WithFilter)
+@mixin(
+    WithReturn,
+    WithSetRemove,
+    WithWith,
+    WithDelete,
+    WithMerge,
+    WithFinish,
+    WithOrder,
+    WithLet,
+    WithFilter,
+    WithCreate
+)
 export class Create extends Clause {
     private readonly pattern: Pattern | PathAssign<Pattern>;
 
@@ -37,21 +59,6 @@ export class Create extends Clause {
         } else {
             this.pattern = new Pattern(pattern);
         }
-    }
-
-    /** Add a {@link Create} clause
-     * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/create/ | Cypher Documentation}
-     */
-    public create(clauseOrPattern: Create | Pattern): Create {
-        if (clauseOrPattern instanceof Create) {
-            this.addNextClause(clauseOrPattern);
-            return clauseOrPattern;
-        }
-
-        const matchClause = new Create(clauseOrPattern);
-        this.addNextClause(matchClause);
-
-        return matchClause;
     }
 
     /** @internal */

--- a/src/clauses/Let.ts
+++ b/src/clauses/Let.ts
@@ -12,6 +12,7 @@ import { WithCallProcedure } from "./mixins/clauses/WithCallProcedure";
 import { WithCreate } from "./mixins/clauses/WithCreate";
 import { WithFilter } from "./mixins/clauses/WithFilter";
 import { WithFinish } from "./mixins/clauses/WithFinish";
+import { WithLet } from "./mixins/clauses/WithLet";
 import { WithMatch } from "./mixins/clauses/WithMatch";
 import { WithMerge } from "./mixins/clauses/WithMerge";
 import { WithReturn } from "./mixins/clauses/WithReturn";
@@ -31,31 +32,32 @@ export interface Let
         WithFinish,
         WithCallProcedure,
         WithCall,
-        WithFilter {}
+        WithFilter,
+        WithLet {}
 
 /**
  * @see {@link https://neo4j.com/docs/cypher-manual/25/clauses/let/ | Cypher Documentation}
  * @group Clauses
  * @since Neo4j 2025.06
  */
-@mixin(WithReturn, WithWith, WithMatch, WithCreate, WithMerge, WithFinish, WithCallProcedure, WithCall, WithFilter)
+@mixin(
+    WithReturn,
+    WithWith,
+    WithMatch,
+    WithCreate,
+    WithMerge,
+    WithFinish,
+    WithCallProcedure,
+    WithCall,
+    WithFilter,
+    WithLet
+)
 export class Let extends Clause {
     private readonly bindings: LetBinding[];
 
     constructor(...bindings: LetBinding[]) {
         super();
         this.bindings = bindings;
-    }
-
-    /** Append a {@link Let} clause.
-     * @see {@link https://neo4j.com/docs/cypher-manual/25/clauses/let/ | Cypher Documentation}
-     */
-    public let(clause: Let): Let;
-    public let(...bindings: LetBinding[]): Let;
-    public let(clauseOrBinding: Let | LetBinding, ...bindings: LetBinding[]): Let {
-        const letClause = this.getLetClause(clauseOrBinding, bindings);
-        this.addNextClause(letClause);
-        return letClause;
     }
 
     /** @internal */
@@ -67,13 +69,5 @@ export class Let extends Clause {
         const nextClause = this.compileNextClause(env);
 
         return `LET ${bindingsStr}${nextClause}`;
-    }
-
-    private getLetClause(clauseOrBinding: Let | LetBinding, bindings: LetBinding[]): Let {
-        if (clauseOrBinding instanceof Let) {
-            return clauseOrBinding;
-        } else {
-            return new Let(clauseOrBinding, ...bindings);
-        }
     }
 }

--- a/src/clauses/Match.ts
+++ b/src/clauses/Match.ts
@@ -16,6 +16,7 @@ import { WithFilter } from "./mixins/clauses/WithFilter";
 import { WithFinish } from "./mixins/clauses/WithFinish";
 import { WithForeach } from "./mixins/clauses/WithForeach";
 import { WithLet } from "./mixins/clauses/WithLet";
+import { WithMatch } from "./mixins/clauses/WithMatch";
 import { WithMerge } from "./mixins/clauses/WithMerge";
 import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithUnwind } from "./mixins/clauses/WithUnwind";
@@ -42,7 +43,8 @@ export interface Match
         WithOrder,
         WithForeach,
         WithLet,
-        WithFilter {}
+        WithFilter,
+        WithMatch {}
 
 enum MatchMode {
     REPEATABLE_ELEMENTS,
@@ -76,7 +78,8 @@ export type MatchClausePattern = Pattern | QuantifiedPath | PathAssign<Pattern |
     WithOrder,
     WithForeach,
     WithLet,
-    WithFilter
+    WithFilter,
+    WithMatch
 )
 export class Match extends Clause {
     private readonly patterns: MatchClausePattern[];
@@ -106,35 +109,6 @@ export class Match extends Clause {
     public optional(): this {
         this._optional = true;
         return this;
-    }
-
-    /** Add a {@link Match} clause
-     * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/match/ | Cypher Documentation}
-     */
-    public match(clauseOrPattern: Match | MatchClausePattern): Match {
-        if (clauseOrPattern instanceof Match) {
-            this.addNextClause(clauseOrPattern);
-            return clauseOrPattern;
-        }
-
-        const matchClause = new Match(clauseOrPattern);
-        this.addNextClause(matchClause);
-
-        return matchClause;
-    }
-
-    /** Add an {@link OptionalMatch} clause
-     * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/optional-match/ | Cypher Documentation}
-     */
-    public optionalMatch(clauseOrPattern: OptionalMatch | MatchClausePattern): OptionalMatch {
-        if (clauseOrPattern instanceof OptionalMatch) {
-            this.addNextClause(clauseOrPattern);
-            return clauseOrPattern;
-        }
-        const matchClause = new OptionalMatch(clauseOrPattern);
-        this.addNextClause(matchClause);
-
-        return matchClause;
     }
 
     /**

--- a/src/clauses/Merge.ts
+++ b/src/clauses/Merge.ts
@@ -13,6 +13,7 @@ import { WithCreate } from "./mixins/clauses/WithCreate";
 import { WithFilter } from "./mixins/clauses/WithFilter";
 import { WithFinish } from "./mixins/clauses/WithFinish";
 import { WithLet } from "./mixins/clauses/WithLet";
+import { WithMerge } from "./mixins/clauses/WithMerge";
 import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
@@ -24,13 +25,34 @@ import { OnMatch } from "./sub-clauses/OnMatch";
 import { mixin } from "./utils/mixin";
 
 export interface Merge
-    extends WithReturn, WithSetRemove, WithDelete, WithWith, WithCreate, WithFinish, WithOrder, WithLet, WithFilter {}
+    extends
+        WithReturn,
+        WithSetRemove,
+        WithDelete,
+        WithWith,
+        WithCreate,
+        WithFinish,
+        WithOrder,
+        WithLet,
+        WithFilter,
+        WithMerge {}
 
 /**
  * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/merge/ | Cypher Documentation}
  * @group Clauses
  */
-@mixin(WithReturn, WithSetRemove, WithDelete, WithWith, WithCreate, WithFinish, WithOrder, WithLet, WithFilter)
+@mixin(
+    WithReturn,
+    WithSetRemove,
+    WithDelete,
+    WithWith,
+    WithCreate,
+    WithFinish,
+    WithOrder,
+    WithLet,
+    WithFilter,
+    WithMerge
+)
 export class Merge extends Clause {
     private readonly pattern: Pattern | PathAssign<Pattern>;
     private readonly onCreateClause: OnCreate;
@@ -52,21 +74,6 @@ export class Merge extends Clause {
     public onMatchSet(...onMatchParams: OnCreateParam[]): this {
         this.onMatchClause.addParams(...onMatchParams);
         return this;
-    }
-
-    /** Add a {@link Merge} clause
-     * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/merge/ | Cypher Documentation}
-     */
-    public merge(clauseOrPattern: Merge | Pattern): Merge {
-        if (clauseOrPattern instanceof Merge) {
-            this.addNextClause(clauseOrPattern);
-            return clauseOrPattern;
-        }
-
-        const matchClause = new Merge(clauseOrPattern);
-        this.addNextClause(matchClause);
-
-        return matchClause;
     }
 
     /** @internal */

--- a/src/clauses/Unwind.ts
+++ b/src/clauses/Unwind.ts
@@ -5,7 +5,6 @@
 
 import type { CypherEnvironment } from "../Environment";
 import type { Expr, Literal, Variable } from "../index";
-import Cypher from "../index";
 import { compileCypherIfExists } from "../utils/compile-cypher-if-exists";
 import { Clause } from "./Clause";
 import { WithCreate } from "./mixins/clauses/WithCreate";
@@ -14,6 +13,7 @@ import { WithLet } from "./mixins/clauses/WithLet";
 import { WithMatch } from "./mixins/clauses/WithMatch";
 import { WithMerge } from "./mixins/clauses/WithMerge";
 import { WithReturn } from "./mixins/clauses/WithReturn";
+import { WithUnwind } from "./mixins/clauses/WithUnwind";
 import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
 import { WithOrder } from "./mixins/sub-clauses/WithOrder";
@@ -32,7 +32,8 @@ export interface Unwind
         WithMerge,
         WithOrder,
         WithLet,
-        WithFilter {}
+        WithFilter,
+        WithUnwind {}
 
 /** @group Clauses */
 export type UnwindProjectionColumn = [Expr, string | Variable | Literal];
@@ -51,7 +52,8 @@ export type UnwindProjectionColumn = [Expr, string | Variable | Literal];
     WithMerge,
     WithOrder,
     WithLet,
-    WithFilter
+    WithFilter,
+    WithUnwind
 )
 export class Unwind extends Clause {
     private readonly projection: Projection;
@@ -59,23 +61,6 @@ export class Unwind extends Clause {
     constructor(projection: UnwindProjectionColumn) {
         super();
         this.projection = new Projection([projection]);
-    }
-
-    // Cannot be part of WithUnwind due to dependency cycles
-    /** Append an {@link Unwind} clause.
-     * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/unwind/ | Cypher Documentation}
-     */
-    public unwind(clause: Unwind): Unwind;
-    public unwind(projection: UnwindProjectionColumn): Unwind;
-    public unwind(clauseOrColumn: Unwind | UnwindProjectionColumn): Unwind {
-        if (clauseOrColumn instanceof Unwind) {
-            this.addNextClause(clauseOrColumn);
-            return clauseOrColumn;
-        } else {
-            const newUnwind = new Cypher.Unwind(clauseOrColumn);
-            this.addNextClause(newUnwind);
-            return newUnwind;
-        }
     }
 
     /** @internal */

--- a/src/clauses/With.ts
+++ b/src/clauses/With.ts
@@ -18,6 +18,7 @@ import { WithMatch } from "./mixins/clauses/WithMatch";
 import { WithMerge } from "./mixins/clauses/WithMerge";
 import { WithReturn } from "./mixins/clauses/WithReturn";
 import { WithUnwind } from "./mixins/clauses/WithUnwind";
+import { WithWith } from "./mixins/clauses/WithWith";
 import { WithDelete } from "./mixins/sub-clauses/WithDelete";
 import { WithOrder } from "./mixins/sub-clauses/WithOrder";
 import { WithSetRemove } from "./mixins/sub-clauses/WithSetRemove";
@@ -45,7 +46,8 @@ export interface With
         WithCall,
         WithDistinctAll,
         WithLet,
-        WithFilter {}
+        WithFilter,
+        WithWith {}
 
 /**
  * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/with/ | Cypher Documentation}
@@ -65,12 +67,12 @@ export interface With
     WithCall,
     WithDistinctAll,
     WithLet,
-    WithFilter
+    WithFilter,
+    WithWith
 )
 export class With extends Clause {
     private readonly projection: Projection;
     private readonly withStatement: With | undefined;
-    private isDistinct = false;
 
     constructor(...columns: Array<"*" | WithProjection>) {
         super();
@@ -80,23 +82,6 @@ export class With extends Clause {
     public addColumns(...columns: Array<"*" | WithProjection>): this {
         this.projection.addColumns(columns);
         return this;
-    }
-
-    public distinct(): this {
-        this.isDistinct = true;
-        return this;
-    }
-
-    // Cannot be part of WithWith due to dependency cycles
-    /** Add a {@link With} clause
-     * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/with/ | Cypher Documentation}
-     */
-    public with(clause: With): With;
-    public with(...columns: Array<"*" | WithProjection>): With;
-    public with(clauseOrColumn: With | "*" | WithProjection, ...columns: Array<"*" | WithProjection>): With {
-        const withClause = this.getWithClause(clauseOrColumn, columns);
-        this.addNextClause(withClause);
-        return withClause;
     }
 
     /** @internal */
@@ -112,13 +97,5 @@ export class With extends Clause {
         const nextClause = this.compileNextClause(env);
 
         return `WITH${projectionModeStr} ${projectionStr}${whereStr}${setCypher}${orderByStr}${deleteStr}${withStr}${nextClause}`;
-    }
-
-    private getWithClause(clauseOrColumn: With | "*" | WithProjection, columns: Array<"*" | WithProjection>): With {
-        if (clauseOrColumn instanceof With) {
-            return clauseOrColumn;
-        } else {
-            return new With(clauseOrColumn, ...columns);
-        }
     }
 }

--- a/src/clauses/mixins/clauses/WithCall.ts
+++ b/src/clauses/mixins/clauses/WithCall.ts
@@ -4,8 +4,10 @@
  */
 
 import type { Clause, Variable } from "../../../index";
-import { Call, OptionalCall } from "../../../index";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import { Call, OptionalCall } from "../../../index";
 
 export abstract class WithCall extends MixinClause {
     /** Add a {@link Call} clause

--- a/src/clauses/mixins/clauses/WithCall.ts
+++ b/src/clauses/mixins/clauses/WithCall.ts
@@ -7,7 +7,7 @@ import type { Clause, Variable } from "../../../index";
 import { MixinClause } from "../Mixin";
 
 // We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
-import { Call, OptionalCall } from "../../../index";
+import { Call, OptionalCall } from "../../../Cypher";
 
 export abstract class WithCall extends MixinClause {
     /** Add a {@link Call} clause

--- a/src/clauses/mixins/clauses/WithCallProcedure.ts
+++ b/src/clauses/mixins/clauses/WithCallProcedure.ts
@@ -3,8 +3,10 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import type { CypherProcedure, VoidCypherProcedure } from "../../../procedures/CypherProcedure";
 import { MixinClause } from "../Mixin";
+
+// These are not public, so they cannot be barrel imported, unlike other mixins
+import type { CypherProcedure, VoidCypherProcedure } from "../../../procedures/CypherProcedure";
 
 export abstract class WithCallProcedure extends MixinClause {
     /** Add a call {@link Procedure} clause

--- a/src/clauses/mixins/clauses/WithCreate.ts
+++ b/src/clauses/mixins/clauses/WithCreate.ts
@@ -4,8 +4,10 @@
  */
 
 import type { Pattern } from "../../../index";
-import { Create } from "../../../index";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import { Create } from "../../../index";
 
 export abstract class WithCreate extends MixinClause {
     /** Add a {@link Create} clause

--- a/src/clauses/mixins/clauses/WithCreate.ts
+++ b/src/clauses/mixins/clauses/WithCreate.ts
@@ -3,11 +3,11 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import type { Pattern } from "../../../index";
+import type { Pattern } from "../../../pattern/Pattern";
 import { MixinClause } from "../Mixin";
 
 // We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
-import { Create } from "../../../index";
+import { Create } from "../../../Cypher";
 
 export abstract class WithCreate extends MixinClause {
     /** Add a {@link Create} clause

--- a/src/clauses/mixins/clauses/WithFinish.ts
+++ b/src/clauses/mixins/clauses/WithFinish.ts
@@ -3,8 +3,10 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import { Finish } from "../../../index";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import { Finish } from "../../../index";
 
 export abstract class WithFinish extends MixinClause {
     /** Append a {@link Finish} clause

--- a/src/clauses/mixins/clauses/WithFinish.ts
+++ b/src/clauses/mixins/clauses/WithFinish.ts
@@ -6,7 +6,7 @@
 import { MixinClause } from "../Mixin";
 
 // We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
-import { Finish } from "../../../index";
+import { Finish } from "../../../Cypher";
 
 export abstract class WithFinish extends MixinClause {
     /** Append a {@link Finish} clause

--- a/src/clauses/mixins/clauses/WithForeach.ts
+++ b/src/clauses/mixins/clauses/WithForeach.ts
@@ -3,9 +3,11 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import type { Foreach } from "../../../index";
 import Cypher from "../../../index";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import type { Foreach } from "../../../index";
 
 export abstract class WithForeach extends MixinClause {
     /** Add a {@link Foreach} clause

--- a/src/clauses/mixins/clauses/WithForeach.ts
+++ b/src/clauses/mixins/clauses/WithForeach.ts
@@ -3,19 +3,19 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import Cypher from "../../../index";
+import type { Variable } from "../../../references/Variable";
 import { MixinClause } from "../Mixin";
 
 // We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
-import type { Foreach } from "../../../index";
+import { Foreach } from "../../../Cypher";
 
 export abstract class WithForeach extends MixinClause {
     /** Add a {@link Foreach} clause
      * @see {@link https://neo4j.com/docs/cypher-manual/current/clauses/foreach/ | Cypher Documentation}
      */
 
-    public foreach(variable: Cypher.Variable): Foreach {
-        const foreach = new Cypher.Foreach(variable);
+    public foreach(variable: Variable): Foreach {
+        const foreach = new Foreach(variable);
         this.addNextClause(foreach);
         return foreach;
     }

--- a/src/clauses/mixins/clauses/WithLet.ts
+++ b/src/clauses/mixins/clauses/WithLet.ts
@@ -4,8 +4,10 @@
  */
 
 import type { LetBinding } from "../../Let";
-import { Let } from "../../Let";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import { Let } from "../../../Cypher";
 
 export abstract class WithLet extends MixinClause {
     /** Append a {@link Let} clause.

--- a/src/clauses/mixins/clauses/WithMatch.ts
+++ b/src/clauses/mixins/clauses/WithMatch.ts
@@ -7,7 +7,7 @@ import type { MatchClausePattern } from "../../Match";
 import { MixinClause } from "../Mixin";
 
 // We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
-import { Match, OptionalMatch } from "../../../index";
+import { Match, OptionalMatch } from "../../../Cypher";
 
 export abstract class WithMatch extends MixinClause {
     /** Add a {@link Match} clause

--- a/src/clauses/mixins/clauses/WithMatch.ts
+++ b/src/clauses/mixins/clauses/WithMatch.ts
@@ -3,9 +3,11 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import { Match, OptionalMatch } from "../../../index";
 import type { MatchClausePattern } from "../../Match";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import { Match, OptionalMatch } from "../../../index";
 
 export abstract class WithMatch extends MixinClause {
     /** Add a {@link Match} clause

--- a/src/clauses/mixins/clauses/WithMerge.ts
+++ b/src/clauses/mixins/clauses/WithMerge.ts
@@ -7,7 +7,7 @@ import type { Pattern } from "../../../index";
 import { MixinClause } from "../Mixin";
 
 // We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
-import { Merge } from "../../../index";
+import { Merge } from "../../../Cypher";
 
 export abstract class WithMerge extends MixinClause {
     /** Add a {@link Merge} clause

--- a/src/clauses/mixins/clauses/WithMerge.ts
+++ b/src/clauses/mixins/clauses/WithMerge.ts
@@ -4,8 +4,10 @@
  */
 
 import type { Pattern } from "../../../index";
-import { Merge } from "../../../index";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import { Merge } from "../../../index";
 
 export abstract class WithMerge extends MixinClause {
     /** Add a {@link Merge} clause

--- a/src/clauses/mixins/clauses/WithReturn.ts
+++ b/src/clauses/mixins/clauses/WithReturn.ts
@@ -3,9 +3,11 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import { Return } from "../../Return";
 import type { ProjectionColumn } from "../../sub-clauses/Projection";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import { Return } from "../../Return";
 
 export abstract class WithReturn extends MixinClause {
     /** Append a {@link Return} clause

--- a/src/clauses/mixins/clauses/WithWith.ts
+++ b/src/clauses/mixins/clauses/WithWith.ts
@@ -3,9 +3,11 @@
  * Neo4j Sweden AB [http://neo4j.com]
  */
 
-import { With } from "../../../index";
 import type { WithProjection } from "../../With";
 import { MixinClause } from "../Mixin";
+
+// We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
+import { With } from "../../../index";
 
 export abstract class WithWith extends MixinClause {
     /** Add a {@link With} clause

--- a/src/clauses/mixins/clauses/WithWith.ts
+++ b/src/clauses/mixins/clauses/WithWith.ts
@@ -7,7 +7,7 @@ import type { WithProjection } from "../../With";
 import { MixinClause } from "../Mixin";
 
 // We need barrel import from Cypher instead of local file to avoid issues with circular dependencies in mixins
-import { With } from "../../../index";
+import { With } from "../../../Cypher";
 
 export abstract class WithWith extends MixinClause {
     /** Add a {@link With} clause


### PR DESCRIPTION
By carefully importing clauses from the barrel import instead of the concrete files, it is possible to sort out the circular dependency of a mixin being used in the class that is instantiated by the mixin.

This allows us to remove the duplicate methods between a clause and its mixin 