### PR TITLE
Improve normalize expr

### DIFF
--- a/src/clauses/sub-clauses/OrderBy.ts
+++ b/src/clauses/sub-clauses/OrderBy.ts
@@ -7,7 +7,7 @@ import { CypherASTNode } from "../../CypherASTNode";
 import type { CypherEnvironment } from "../../Environment";
 import type { Expr } from "../../types";
 import { compileCypherIfExists } from "../../utils/compile-cypher-if-exists";
-import { normalizeExpr } from "../../utils/normalize-variable";
+import { normalizeExpr } from "../../utils/normalize-expr";
 
 /** @group Clauses */
 export type Order = "ASC" | "DESC";

--- a/src/expressions/functions/aggregation.ts
+++ b/src/expressions/functions/aggregation.ts
@@ -5,7 +5,7 @@
 
 import type { CypherEnvironment } from "../../Environment";
 import type { Expr } from "../../types";
-import { normalizeExpr } from "../../utils/normalize-variable";
+import { normalizeExpr } from "../../utils/normalize-expr";
 import { CypherFunction } from "./CypherFunctions";
 
 /**

--- a/src/expressions/functions/list.ts
+++ b/src/expressions/functions/list.ts
@@ -34,7 +34,7 @@ export function labels(nodeRef: Expr): CypherFunction {
  * @category List
  */
 export function range(start: Expr | number, end: Expr | number, step?: Expr | number): CypherFunction {
-    const params = filterTruthy([start, end, step]).map(normalizeExpr);
+    const params = filterTruthy([start, end, step]).map((arg) => normalizeExpr(arg));
     return new CypherFunction("range", params);
 }
 

--- a/src/expressions/functions/list.ts
+++ b/src/expressions/functions/list.ts
@@ -7,7 +7,7 @@ import type { CypherEnvironment } from "../../Environment";
 import type { Variable } from "../../references/Variable";
 import type { Expr } from "../../types";
 import { filterTruthy } from "../../utils/filter-truthy";
-import { normalizeExpr } from "../../utils/normalize-variable";
+import { normalizeExpr } from "../../utils/normalize-expr";
 import { CypherFunction } from "./CypherFunctions";
 
 /**

--- a/src/expressions/functions/string.ts
+++ b/src/expressions/functions/string.ts
@@ -18,7 +18,7 @@ import { CypherFunction } from "./CypherFunctions";
  */
 export function btrim(original: string | Expr, trimCharacter?: string | Expr): CypherFunction {
     const normalizedOriginal = normalizeExpr(original);
-    const normalizedTrimCharacter = trimCharacter ? normalizeExpr(trimCharacter) : undefined;
+    const normalizedTrimCharacter = normalizeExpr(trimCharacter);
     return new CypherFunction("btrim", filterTruthy([normalizedOriginal, normalizedTrimCharacter]));
 }
 
@@ -48,7 +48,7 @@ export function lower(original: Expr): CypherFunction {
  */
 export function ltrim(original: Expr | string, trimCharacter?: string | Expr): CypherFunction {
     const normalizedOriginal = normalizeExpr(original);
-    const normalizedTrimCharacter = trimCharacter ? normalizeExpr(trimCharacter) : undefined;
+    const normalizedTrimCharacter = normalizeExpr(trimCharacter);
     return new CypherFunction("ltrim", filterTruthy([normalizedOriginal, normalizedTrimCharacter]));
 }
 
@@ -61,7 +61,7 @@ export function ltrim(original: Expr | string, trimCharacter?: string | Expr): C
  * @example `Cypher.normalize(param, "NFC")`
  */
 export function normalize(input: Expr, normalForm?: NormalizationType | Expr): CypherFunction {
-    const normalFormExpr = normalForm ? normalizeExpr(normalForm) : undefined;
+    const normalFormExpr = normalizeExpr(normalForm);
     return new CypherFunction("normalize", filterTruthy([input, normalFormExpr]));
 }
 
@@ -91,7 +91,7 @@ export function right(original: Expr, length: Expr): CypherFunction {
  */
 export function rtrim(original: Expr | string, trimCharacter?: string | Expr): CypherFunction {
     const normalizedOriginal = normalizeExpr(original);
-    const normalizedTrimCharacter = trimCharacter ? normalizeExpr(trimCharacter) : undefined;
+    const normalizedTrimCharacter = normalizeExpr(trimCharacter);
     return new CypherFunction("rtrim", filterTruthy([normalizedOriginal, normalizedTrimCharacter]));
 }
 

--- a/src/expressions/functions/string.ts
+++ b/src/expressions/functions/string.ts
@@ -6,7 +6,7 @@
 import type { CypherEnvironment } from "../../Environment";
 import type { Expr, NormalizationType } from "../../types";
 import { filterTruthy } from "../../utils/filter-truthy";
-import { normalizeExpr } from "../../utils/normalize-variable";
+import { normalizeExpr } from "../../utils/normalize-expr";
 
 import { CypherFunction } from "./CypherFunctions";
 

--- a/src/expressions/functions/temporal.ts
+++ b/src/expressions/functions/temporal.ts
@@ -5,7 +5,7 @@
 
 import { Literal } from "../../references/Literal";
 import type { Expr } from "../../types";
-import { normalizeExpr } from "../../utils/normalize-variable";
+import { normalizeExpr } from "../../utils/normalize-expr";
 import { CypherFunction } from "./CypherFunctions";
 
 /** Temporal unit to be used in `.truncate()` functions

--- a/src/namespaces/db/cdc.ts
+++ b/src/namespaces/db/cdc.ts
@@ -5,7 +5,7 @@
 
 import { CypherProcedure } from "../../procedures/CypherProcedure";
 import type { Expr } from "../../types";
-import { normalizeExpr, normalizeList } from "../../utils/normalize-variable";
+import { normalizeExpr, normalizeList } from "../../utils/normalize-expr";
 
 const CDC_NAMESPACE = "db.cdc";
 

--- a/src/namespaces/db/db.ts
+++ b/src/namespaces/db/db.ts
@@ -6,7 +6,7 @@
 import { CypherFunction } from "../../expressions/functions/CypherFunctions";
 import { CypherProcedure, VoidCypherProcedure } from "../../procedures/CypherProcedure";
 import type { Expr } from "../../types";
-import { normalizeExpr } from "../../utils/normalize-variable";
+import { normalizeExpr } from "../../utils/normalize-expr";
 
 export * as cdc from "./cdc";
 /**

--- a/src/namespaces/db/index/fulltext.ts
+++ b/src/namespaces/db/index/fulltext.ts
@@ -9,7 +9,7 @@ import type { Literal } from "../../../references/Literal";
 import type { Param } from "../../../references/Param";
 import type { Variable } from "../../../references/Variable";
 import type { Expr } from "../../../types";
-import { normalizeMap, normalizeVariable } from "../../../utils/normalize-variable";
+import { normalizeExpr, normalizeMap } from "../../../utils/normalize-variable";
 
 type FulltextPhrase = string | Literal<string> | Param | Variable;
 
@@ -64,8 +64,8 @@ function getFulltextArguments(
     queryString: FulltextPhrase,
     options?: { skip?: InputArgument<number>; limit?: InputArgument<number>; analyser?: InputArgument<string> }
 ): Expr[] {
-    const phraseVar = normalizeVariable(queryString);
-    const indexNameVar = normalizeVariable(indexName);
+    const phraseVar = normalizeExpr(queryString);
+    const indexNameVar = normalizeExpr(indexName);
 
     const procedureArgs: Expr[] = [indexNameVar, phraseVar];
     if (options) {

--- a/src/namespaces/db/index/fulltext.ts
+++ b/src/namespaces/db/index/fulltext.ts
@@ -9,7 +9,7 @@ import type { Literal } from "../../../references/Literal";
 import type { Param } from "../../../references/Param";
 import type { Variable } from "../../../references/Variable";
 import type { Expr } from "../../../types";
-import { normalizeExpr, normalizeMap } from "../../../utils/normalize-variable";
+import { normalizeExpr, normalizeMap } from "../../../utils/normalize-expr";
 
 type FulltextPhrase = string | Literal<string> | Param | Variable;
 

--- a/src/namespaces/db/index/vector.ts
+++ b/src/namespaces/db/index/vector.ts
@@ -6,7 +6,7 @@
 import type { Literal } from "../../../Cypher";
 import { CypherProcedure } from "../../../procedures/CypherProcedure";
 import type { Expr } from "../../../types";
-import { normalizeExpr } from "../../../utils/normalize-variable";
+import { normalizeExpr } from "../../../utils/normalize-expr";
 
 const VECTOR_NAMESPACE = "db.index.vector";
 

--- a/src/namespaces/db/index/vector.ts
+++ b/src/namespaces/db/index/vector.ts
@@ -6,7 +6,7 @@
 import type { Literal } from "../../../Cypher";
 import { CypherProcedure } from "../../../procedures/CypherProcedure";
 import type { Expr } from "../../../types";
-import { normalizeVariable } from "../../../utils/normalize-variable";
+import { normalizeExpr } from "../../../utils/normalize-variable";
 
 const VECTOR_NAMESPACE = "db.index.vector";
 
@@ -43,8 +43,8 @@ function getVectorArguments(
     numberOfNearestNeighbours: number,
     query: Expr
 ): Expr[] {
-    const indexNameVar = normalizeVariable(indexName);
-    const numberOfNearestNeighboursVar = normalizeVariable(numberOfNearestNeighbours);
+    const indexNameVar = normalizeExpr(indexName);
+    const numberOfNearestNeighboursVar = normalizeExpr(numberOfNearestNeighbours);
 
     const procedureArgs: Expr[] = [indexNameVar, numberOfNearestNeighboursVar, query];
     return procedureArgs;

--- a/src/namespaces/genai/vector.ts
+++ b/src/namespaces/genai/vector.ts
@@ -7,7 +7,7 @@ import type { Literal, Param } from "../../Cypher";
 import { CypherFunction } from "../../expressions/functions/CypherFunctions";
 import { CypherProcedure } from "../../procedures/CypherProcedure";
 import type { Expr } from "../../types";
-import { normalizeExpr, normalizeMap } from "../../utils/normalize-variable";
+import { normalizeExpr, normalizeMap } from "../../utils/normalize-expr";
 
 const GENAI_VECTOR_NAMESPACE = "genai.vector";
 

--- a/src/namespaces/genai/vector.ts
+++ b/src/namespaces/genai/vector.ts
@@ -7,7 +7,7 @@ import type { Literal, Param } from "../../Cypher";
 import { CypherFunction } from "../../expressions/functions/CypherFunctions";
 import { CypherProcedure } from "../../procedures/CypherProcedure";
 import type { Expr } from "../../types";
-import { normalizeMap, normalizeVariable } from "../../utils/normalize-variable";
+import { normalizeExpr, normalizeMap } from "../../utils/normalize-variable";
 
 const GENAI_VECTOR_NAMESPACE = "genai.vector";
 
@@ -22,7 +22,7 @@ export function encode(
 ): CypherFunction {
     return new CypherFunction(
         "encode",
-        [resource, normalizeVariable(provider), normalizeMap(configuration)],
+        [resource, normalizeExpr(provider), normalizeMap(configuration)],
         GENAI_VECTOR_NAMESPACE
     );
 }
@@ -38,7 +38,7 @@ export function encodeBatch(
 ): CypherProcedure<"index" | "resource" | "vector"> {
     return new CypherProcedure(
         "encodeBatch",
-        [resources, normalizeVariable(provider), normalizeMap(configuration)],
+        [resources, normalizeExpr(provider), normalizeMap(configuration)],
         GENAI_VECTOR_NAMESPACE
     );
 }

--- a/src/namespaces/tx.ts
+++ b/src/namespaces/tx.ts
@@ -7,7 +7,7 @@ import type { VoidCypherProcedure } from "../procedures/CypherProcedure";
 import { CypherProcedure } from "../procedures/CypherProcedure";
 import type { Literal } from "../references/Literal";
 import type { Param } from "../references/Param";
-import { normalizeMap } from "../utils/normalize-variable";
+import { normalizeMap } from "../utils/normalize-expr";
 
 const TX_NAMESPACE = "tx";
 

--- a/src/utils/normalize-expr.test.ts
+++ b/src/utils/normalize-expr.test.ts
@@ -4,7 +4,7 @@
  */
 
 import Cypher from "../index";
-import { normalizeExpr } from "./normalize-variable";
+import { normalizeExpr } from "./normalize-expr";
 
 describe("normalizeExpr", () => {
     test("returns the same variable if it is a CypherCompilable", () => {

--- a/src/utils/normalize-expr.ts
+++ b/src/utils/normalize-expr.ts
@@ -13,7 +13,7 @@ import { isCypherCompilable } from "./is-cypher-compilable";
 /** Something that can be coerced into a Variable */
 type VariableLike = string | number | Variable | Literal;
 
-/** Coerces a VariableLike into an Expression. Returns undefined if the value is undefined */
+/** Coerces a {@link VariableLike} into an Expression. Returns undefined if the value is undefined */
 export function normalizeExpr(value: undefined): undefined;
 export function normalizeExpr(value: VariableLike | Expr): Expr;
 export function normalizeExpr(value: VariableLike | Expr | undefined): Expr | undefined;
@@ -23,13 +23,15 @@ export function normalizeExpr(value: VariableLike | Expr | undefined): Expr | un
     return new Literal(value);
 }
 
-export function normalizeMap(map: Record<string, VariableLike>): MapExpr {
+/** Applies {@link normalizeExpr} to the properties of a map. Returns a {@link MapExpr} */
+export function normalizeMap(map: Record<string, VariableLike | Expr>): MapExpr {
     return Object.entries(map).reduce((mapExpr, [key, value]) => {
         mapExpr.set(key, normalizeExpr(value));
         return mapExpr;
     }, new MapExpr());
 }
 
+/** Applies {@link normalizeExpr} to the elements of a list. Returns a {@link ListExpr} */
 export function normalizeList(list: Array<VariableLike | Expr>): ListExpr {
     const expressions = list.map((v) => normalizeExpr(v));
     return new ListExpr(expressions);

--- a/src/utils/normalize-variable.test.ts
+++ b/src/utils/normalize-variable.test.ts
@@ -4,18 +4,18 @@
  */
 
 import Cypher from "../index";
-import { normalizeVariable } from "./normalize-variable";
+import { normalizeExpr } from "./normalize-variable";
 
-describe("normalizeVariable", () => {
+describe("normalizeExpr", () => {
     test("returns the same variable if it is a CypherCompilable", () => {
         const originalVariable = new Cypher.Literal("hello");
-        const result = normalizeVariable(originalVariable);
+        const result = normalizeExpr(originalVariable);
 
         expect(result).toEqual(originalVariable);
     });
 
     test("generates a new literal variable if it is a primitive value", () => {
-        const result = normalizeVariable(5);
+        const result = normalizeExpr(5);
 
         expect(result).toBeInstanceOf(Cypher.Literal);
     });

--- a/src/utils/normalize-variable.ts
+++ b/src/utils/normalize-variable.ts
@@ -6,32 +6,31 @@
 import { ListExpr } from "../expressions/list/ListExpr";
 import { MapExpr } from "../expressions/map/MapExpr";
 import { Literal } from "../references/Literal";
-import type { Param } from "../references/Param";
 import type { Variable } from "../references/Variable";
 import type { Expr } from "../types";
 import { isCypherCompilable } from "./is-cypher-compilable";
 
-type VariableInput = string | number | Variable | Literal | Param;
+/** Something that can be coerced into a Variable */
+type VariableLike = string | number | Variable | Literal;
 
-export function normalizeVariable(value: VariableInput): Variable | Literal | Param {
+/** Coerces a VariableLike into an Expression. Returns undefined if the value is undefined */
+export function normalizeExpr(value: undefined): undefined;
+export function normalizeExpr(value: VariableLike | Expr): Expr;
+export function normalizeExpr(value: VariableLike | Expr | undefined): Expr | undefined;
+export function normalizeExpr(value: VariableLike | Expr | undefined): Expr | undefined {
+    if (!value) return undefined;
     if (isCypherCompilable(value)) return value;
     return new Literal(value);
 }
 
-// Same as normalizeVariable, just typings are different
-export function normalizeExpr(value: VariableInput | Expr): Variable | Literal | Param | Expr {
-    if (isCypherCompilable(value)) return value;
-    return new Literal(value);
-}
-
-export function normalizeMap(map: Record<string, VariableInput>): MapExpr {
+export function normalizeMap(map: Record<string, VariableLike>): MapExpr {
     return Object.entries(map).reduce((mapExpr, [key, value]) => {
-        mapExpr.set(key, normalizeVariable(value));
+        mapExpr.set(key, normalizeExpr(value));
         return mapExpr;
     }, new MapExpr());
 }
 
-export function normalizeList(list: Array<VariableInput | Expr>): ListExpr {
+export function normalizeList(list: Array<VariableLike | Expr>): ListExpr {
     const expressions = list.map((v) => normalizeExpr(v));
     return new ListExpr(expressions);
 }


### PR DESCRIPTION
This PR removes the redundant method `normalizeVariable` and improves `normalizeExpr` to support undefined values, making more consistent its use across function arguments