### PR TITLE
Revert change: Emit methods and classes marked as internal again.

### DIFF
--- a/.changeset/sparkly-cooks-give.md
+++ b/.changeset/sparkly-cooks-give.md
@@ -1,0 +1,8 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Revert change: Emit methods and classes marked as internal again.
+
+This change was introduced in v3.1.0 as an optimisation of the bundle, and to provide better typings,
+but caused some incompatibilities when using `compile`

--- a/tsconfig.production.json
+++ b/tsconfig.production.json
@@ -5,7 +5,7 @@
         "outDir": "dist",
         "declarationMap": false,
         "sourceMap": false,
-        "stripInternal": true
+        "stripInternal": false
     },
     "exclude": ["src/**/*.test.ts"],
     "include": ["src/**/*"]


### PR DESCRIPTION
This change was introduced in v3.1.0 as an optimisation of the bundle, and to provide better typings,
but caused some incompatibilities when using `compile`